### PR TITLE
Fix some wierd styles

### DIFF
--- a/lib/google/gax.rb
+++ b/lib/google/gax.rb
@@ -52,14 +52,14 @@ module Google
       # @param timeout [Numeric] The client-side timeout for API calls. This
       #   parameter is ignored for retrying calls.
       # @param retry_options [RetryOptions] The configuration for retrying upon
-      #   transient error. If set to None, this call will not retry.
+      #   transient error. If set to nil, this call will not retry.
       # @param page_descriptor [PageDescriptor] indicates the structure of page
-      #   streaming to be performed. If set to None, page streaming is not
+      #   streaming to be performed. If set to nil, page streaming is not
       #   performed.
-      # @param bundler orchestrates bundling. If None, bundling is not
+      # @param bundler orchestrates bundling. If nil, bundling is not
       #   performed.
       # @param bundle_descriptor [BundleDescriptor] indicates the structure of
-      #   the bundle. If None, bundling is not performed.
+      #   the bundle. If nil, bundling is not performed.
       def initialize(timeout: 30, retry_options: nil, page_descriptor: nil,
                      bundler: nil, bundle_descriptor: nil)
         @timeout = timeout
@@ -205,7 +205,7 @@ module Google
                                         :subresponse_field)
       # @!attribute bundled_field
       #   @return [String] the repeated field in the request message
-      #     that will have its elements aggregated by bundling
+      #     that will have its elements aggregated by bundling.
       # @!attribute request_discriminator_fields
       #   @return [Array<String>] a list of fields in the target
       #     request message class that are used to determine which

--- a/lib/google/gax/grpc.rb
+++ b/lib/google/gax/grpc.rb
@@ -48,20 +48,21 @@ module Google
       #
       # @param port [Fixnum] The port on which to connect to the remote host.
       #
-      # @param chan_creds [Object] A ClientCredentials object for use with an
-      #    SSL-enabled Channel. If none, credentials are pulled from a default
-      #    location.
+      # @param chan_creds [Grpc::Core::ChannelCredentials]
+      #   A ChannelCredentials object for use with an SSL-enabled Channel.
+      #   If nil, credentials are pulled from a default location.
       #
-      # @param channel [Object] A Channel object through which to make calls. If
-      #    none, a secure channel is constructed.
+      # @param channel [Object]
+      #   A Channel object through which to make calls. If nil, a secure
+      #   channel is constructed.
       #
       # @param updater_proc [Proc]
-      #    A function that transforms the metadata for requests, e.g., to give
-      #    OAuth credentials.
+      #   A function that transforms the metadata for requests, e.g., to give
+      #   OAuth credentials.
       #
       # @param scopes [Array<String>]
-      #    The OAuth scopes for this service. This parameter is ignored if
-      #    a custom metadata_transformer is supplied.
+      #   The OAuth scopes for this service. This parameter is ignored if
+      #   a custom metadata_transformer is supplied.
       #
       # @yield [address, creds]
       #   the generated gRPC method to create a stub.


### PR DESCRIPTION
This happened because gax-ruby originally borrowed the logic
and documentation string from gax-python -- some things are
not very ruby-ish.

- remove underscore-prefixed names: this is simply Pythonic
  style but not necessary in Ruby. They are already marked
  as private in the code.
- fix comments, mostly s/None/nil/

This fixes #15