### PR TITLE
Removed the GRPC dependency from api_callable.

### DIFF
--- a/lib/google/gax.rb
+++ b/lib/google/gax.rb
@@ -53,7 +53,7 @@ module Google
     #   @return [Hash]
     class CallSettings
       attr_reader :timeout, :retry_options, :page_descriptor, :page_token,
-                  :bundler, :bundle_descriptor, :kwargs
+                  :bundler, :bundle_descriptor, :kwargs, :errors
 
       # @param timeout [Numeric] The client-side timeout for API calls. This
       #   parameter is ignored for retrying calls.
@@ -71,9 +71,11 @@ module Google
       #   the bundle. If nil, bundling is not performed.
       # @param kwargs [Hash]
       #   Additional keyword argments to be passed to the API call.
+      # @param errors [Array<Exception>]
+      #   Configures the exceptions to wrap with GaxError.
       def initialize(timeout: 30, retry_options: nil, page_descriptor: nil,
                      page_token: nil, bundler: nil, bundle_descriptor: nil,
-                     kwargs: {})
+                     kwargs: {}, errors: [])
         @timeout = timeout
         @retry_options = retry_options
         @page_descriptor = page_descriptor
@@ -81,6 +83,7 @@ module Google
         @bundler = bundler
         @bundle_descriptor = bundle_descriptor
         @kwargs = kwargs
+        @errors = errors
       end
 
       # @return true when it has retry codes.
@@ -105,7 +108,8 @@ module Google
                                   page_token: @page_token,
                                   bundler: @bundler,
                                   bundle_descriptor: @bundle_descriptor,
-                                  kwargs: @kwargs)
+                                  kwargs: @kwargs,
+                                  errors: @errors)
         end
 
         timeout = if options.timeout == :OPTION_INHERIT
@@ -133,7 +137,8 @@ module Google
                          page_token: page_token,
                          bundler: @bundler,
                          bundle_descriptor: @bundle_descriptor,
-                         kwargs: kwargs)
+                         kwargs: kwargs,
+                         errors: @errors)
       end
     end
 

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -30,7 +30,6 @@
 require 'time'
 
 require 'google/gax/errors'
-require 'google/gax/grpc'
 
 # rubocop:disable Metrics/ModuleLength
 
@@ -217,7 +216,7 @@ module Google
     # does the signature change.
     #
     # @param func [Proc] used to make a bare rpc call
-    # @param settings [CallSettings provides the settings for this call
+    # @param settings [CallSettings] provides the settings for this call
     # @return [Proc] a bound method on a request stub used to make an rpc call
     # @raise [StandardError] if +settings+ has incompatible values,
     #   e.g, if bundling and page_streaming are both configured
@@ -248,7 +247,7 @@ module Google
                      add_timeout_arg(func, this_settings.timeout,
                                      this_settings.kwargs)
                    end
-        api_call = catch_errors(api_call)
+        api_call = catch_errors(api_call, settings.errors)
         api_caller.call(api_call, request, this_settings)
       end
     end
@@ -257,8 +256,8 @@ module Google
     #
     # @param a_func [Proc]
     # @param errors [Array<Exception>] Configures the exceptions to wrap.
-    # @return [Proc] A proc that will wrap certain exceptions with GaxError
-    def catch_errors(a_func, errors: Grpc::API_ERRORS)
+    # @return [Proc] A proc that will wrap certain exceptions with GaxError.
+    def catch_errors(a_func, errors)
       proc do |request|
         begin
           a_func.call(request)

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -185,11 +185,13 @@ module Google
     #   methods that are page streaming-enabled.
     # @param kwargs [Hash]
     #   Additional keyword argments to be passed to the API call.
+    # @param errors [Array<Exception>]
+    #   Configures the exceptions to wrap with GaxError.
     # @return [CallSettings, nil] A CallSettings, or nil if the
     #   service is not found in the config.
     def construct_settings(service_name, client_config, config_overrides,
                            retry_names, timeout, bundle_descriptors: {},
-                           page_descriptors: {}, kwargs: {})
+                           page_descriptors: {}, kwargs: {}, errors: [])
       defaults = {}
 
       service_config = client_config.fetch('interfaces', {})[service_name]
@@ -225,7 +227,7 @@ module Google
           bundler: construct_bundling(bundling_config,
                                       bundle_descriptor),
           bundle_descriptor: bundle_descriptor,
-          kwargs: kwargs
+          kwargs: kwargs, errors: errors
         )
       end
 

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -117,7 +117,7 @@ describe Google::Gax do
 
   describe 'failures without retry' do
     it 'simply fails' do
-      settings = CallSettings.new
+      settings = CallSettings.new(errors: [GRPC::Cancelled])
       timeout_arg = nil
       call_count = 0
       func = proc do |timeout: nil|

--- a/spec/google/gax/settings_spec.rb
+++ b/spec/google/gax/settings_spec.rb
@@ -91,7 +91,8 @@ describe Google::Gax do
       SERVICE_NAME, A_CONFIG, {}, RETRY_DICT, 30,
       bundle_descriptors: BUNDLE_DESCRIPTORS,
       page_descriptors: PAGE_DESCRIPTORS,
-      kwargs: { 'key' => 'value' }
+      kwargs: { 'key' => 'value' },
+      errors: [StandardError]
     )
     settings = defaults['bundling_method']
     expect(settings.timeout).to be(30)
@@ -105,6 +106,7 @@ describe Google::Gax do
       Google::Gax::BackoffSettings
     )
     expect(settings.kwargs).to match('key' => 'value')
+    expect(settings.errors).to match_array([StandardError])
 
     settings = defaults['page_streaming_method']
     expect(settings.timeout).to be(30)
@@ -117,6 +119,7 @@ describe Google::Gax do
       Google::Gax::BackoffSettings
     )
     expect(settings.kwargs).to match('key' => 'value')
+    expect(settings.errors).to match_array([StandardError])
   end
 
   it 'overrides settings' do


### PR DESCRIPTION
https://github.com/googleapis/gax-ruby/issues/26.

In this commit, errors are not treated as overridable.