### PR TITLE
Use metadata argument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,3 +35,6 @@ Style/Documentation:
 Style/StructInheritance:
   Exclude:
     - 'lib/google/gax.rb'
+
+Style/NumericPredicate:
+  Enabled: false

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -376,7 +376,7 @@ module Google
     # @return [Proc] the original proc updated to the timeout arg
     def add_timeout_arg(a_func, timeout, kwargs)
       proc do |request|
-        a_func.call(request, deadline: Time.now + timeout, **kwargs)
+        a_func.call(request, deadline: Time.now + timeout, metadata: kwargs)
       end
     end
 

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.4.1'.freeze
+    VERSION = '0.4.2'.freeze
   end
 end

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -49,7 +49,7 @@ describe Google::Gax do
     it 'calls api call' do
       settings = CallSettings.new
       deadline_arg = nil
-      func = proc do |deadline: nil, metadata: nil|
+      func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         42
       end
@@ -72,7 +72,7 @@ describe Google::Gax do
                                                       'next_page_token', 'nums')
     settings = CallSettings.new(page_descriptor: page_descriptor)
     deadline_arg = nil
-    func = proc do |request, deadline: nil, metadata: nil|
+    func = proc do |request, deadline: nil, **_kwargs|
       deadline_arg = deadline
       page_token = request['page_token']
       if page_token > 0 && page_token < page_size * pages_to_stream
@@ -120,7 +120,7 @@ describe Google::Gax do
       settings = CallSettings.new(errors: [GRPC::Cancelled])
       deadline_arg = nil
       call_count = 0
-      func = proc do |deadline: nil, metadata: nil|
+      func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         call_count += 1
         raise GRPC::Cancelled, ''
@@ -140,7 +140,7 @@ describe Google::Gax do
       settings = CallSettings.new
       deadline_arg = nil
       call_count = 0
-      func = proc do |deadline: nil, metadata: nil|
+      func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         call_count += 1
         raise CustomException.new('', FAKE_STATUS_CODE_1)
@@ -207,7 +207,7 @@ describe Google::Gax do
       to_attempt = 3
 
       deadline_arg = nil
-      func = proc do |deadline: nil, metadata: nil|
+      func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         to_attempt -= 1
         raise CustomException.new('', FAKE_STATUS_CODE_1) if to_attempt > 0
@@ -260,7 +260,7 @@ describe Google::Gax do
       )
 
       deadline_arg = nil
-      func = proc do |deadline: nil, metadata: nil|
+      func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         call_count += 1
         raise CustomException.new('', FAKE_STATUS_CODE_1)
@@ -299,7 +299,7 @@ describe Google::Gax do
       start_time = time_now
       incr_time = proc { |secs| time_now += secs }
       call_count = 0
-      func = proc do |_, deadline: nil, metadata: nil|
+      func = proc do |_, deadline: nil, **_kwargs|
         call_count += 1
         incr_time.call(deadline - time_now)
         raise CustomException.new(deadline.to_s, FAKE_STATUS_CODE_1)

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -49,7 +49,7 @@ describe Google::Gax do
     it 'calls api call' do
       settings = CallSettings.new
       deadline_arg = nil
-      func = proc do |deadline: nil|
+      func = proc do |deadline: nil, metadata: nil|
         deadline_arg = deadline
         42
       end
@@ -72,7 +72,7 @@ describe Google::Gax do
                                                       'next_page_token', 'nums')
     settings = CallSettings.new(page_descriptor: page_descriptor)
     deadline_arg = nil
-    func = proc do |request, deadline: nil|
+    func = proc do |request, deadline: nil, metadata: nil|
       deadline_arg = deadline
       page_token = request['page_token']
       if page_token > 0 && page_token < page_size * pages_to_stream
@@ -120,7 +120,7 @@ describe Google::Gax do
       settings = CallSettings.new(errors: [GRPC::Cancelled])
       deadline_arg = nil
       call_count = 0
-      func = proc do |deadline: nil|
+      func = proc do |deadline: nil, metadata: nil|
         deadline_arg = deadline
         call_count += 1
         raise GRPC::Cancelled, ''
@@ -140,7 +140,7 @@ describe Google::Gax do
       settings = CallSettings.new
       deadline_arg = nil
       call_count = 0
-      func = proc do |deadline: nil|
+      func = proc do |deadline: nil, metadata: nil|
         deadline_arg = deadline
         call_count += 1
         raise CustomException.new('', FAKE_STATUS_CODE_1)
@@ -207,7 +207,7 @@ describe Google::Gax do
       to_attempt = 3
 
       deadline_arg = nil
-      func = proc do |deadline: nil|
+      func = proc do |deadline: nil, metadata: nil|
         deadline_arg = deadline
         to_attempt -= 1
         raise CustomException.new('', FAKE_STATUS_CODE_1) if to_attempt > 0
@@ -260,7 +260,7 @@ describe Google::Gax do
       )
 
       deadline_arg = nil
-      func = proc do |deadline: nil|
+      func = proc do |deadline: nil, metadata: nil|
         deadline_arg = deadline
         call_count += 1
         raise CustomException.new('', FAKE_STATUS_CODE_1)
@@ -299,7 +299,7 @@ describe Google::Gax do
       start_time = time_now
       incr_time = proc { |secs| time_now += secs }
       call_count = 0
-      func = proc do |_, deadline: nil|
+      func = proc do |_, deadline: nil, metadata: nil|
         call_count += 1
         incr_time.call(deadline - time_now)
         raise CustomException.new(deadline.to_s, FAKE_STATUS_CODE_1)


### PR DESCRIPTION
gRPC 0.15.0 actually assumes metadata: argument rather than kwargs.