### PR TITLE
Update gRPC dependency on 1.0.0.pre1

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'googleauth', '~> 0.5.1'
-  s.add_dependency 'grpc', '~> 0.15.0'
+  s.add_dependency 'grpc', '= 1.0.0.pre1'
   s.add_dependency 'rly', '~> 0.2.3'
 
   s.add_development_dependency 'codecov', '~> 0.1'

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.4.2'.freeze
+    VERSION = '0.4.3'.freeze
   end
 end


### PR DESCRIPTION
Previous 0.15.0 causes version inconsistency with gcloud-ruby.