### PR TITLE
Hide CallSettings as private.

### DIFF
--- a/lib/google/gax.rb
+++ b/lib/google/gax.rb
@@ -35,6 +35,7 @@ require 'google/gax/settings'
 require 'google/gax/version'
 
 module Google
+  # Gax defines Google API extensions
   module Gax
     # rubocop:disable Metrics/ParameterLists
 
@@ -141,6 +142,8 @@ module Google
                          errors: @errors)
       end
     end
+
+    private_constant :CallSettings
 
     # Encapsulates the overridable settings for a particular API call
     # @!attribute [r] timeout

--- a/lib/google/gax/bundling.rb
+++ b/lib/google/gax/bundling.rb
@@ -27,14 +27,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# rubocop:disable Style/Documentation
+# Without this, somehow rubocop raises an warning for documentaion for
+# module Gax, however it's documented in lib/google/gax.rb.
+
 module Google
-  # Gax defines Google API extensions
   module Gax
     DEMUX_WARNING = [
       'Warning: cannot demultiplex the bundled response, got ',
       '%d subresponses; want %d, each bundled request will ',
       'receive all responses'
     ].join
+
+    # rubocop:enable Style/Documentation
 
     # Helper function for #compute_bundle_id.
     # Used to retrieve a nested field signified by name where dots in name

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -42,9 +42,16 @@ end
 FAKE_STATUS_CODE_1 = :FAKE_STATUS_CODE_1
 FAKE_STATUS_CODE_2 = :FAKE_STATUS_CODE_2
 
-describe Google::Gax do
-  CallSettings = Google::Gax::CallSettings
+# Google::Gax::CallSettings is private, only accessible in the module context.
+# For testing purpose, this makes a toplevel ::CallSettings point to the same
+# class.
+module Google
+  module Gax
+    ::CallSettings = CallSettings
+  end
+end
 
+describe Google::Gax do
   describe 'create_api_call' do
     it 'calls api call' do
       settings = CallSettings.new


### PR DESCRIPTION
In Ruby, a 'private constant' is a constant which will have
to be accessed without prefix. So all entties inside of
Google::Gax can still access it as-is, but outside the module
it can't be accessed as Google::Gax::CallSettings.

This affects the tests, so this patch introduced a renaming
to toplevel ::CallSettings in a way to avoid violating
access of private constant.

updates https://github.com/googleapis/gax-python/issues/112