### PR TITLE
Exclude loading grpc when require 'google/gax'.

### DIFF
--- a/lib/google/gax.rb
+++ b/lib/google/gax.rb
@@ -29,7 +29,6 @@
 
 require 'google/gax/api_callable'
 require 'google/gax/errors'
-require 'google/gax/grpc'
 require 'google/gax/path_template'
 require 'google/gax/settings'
 require 'google/gax/version'

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.4.4'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -124,20 +124,20 @@ describe Google::Gax do
 
   describe 'failures without retry' do
     it 'simply fails' do
-      settings = CallSettings.new(errors: [GRPC::Cancelled])
+      settings = CallSettings.new(errors: [CustomException])
       deadline_arg = nil
       call_count = 0
       func = proc do |deadline: nil, **_kwargs|
         deadline_arg = deadline
         call_count += 1
-        raise GRPC::Cancelled, ''
+        raise CustomException.new('', FAKE_STATUS_CODE_1)
       end
       my_callable = Google::Gax.create_api_call(func, settings)
       begin
         my_callable.call
         expect(true).to be false # should not reach to this line.
       rescue Google::Gax::GaxError => exc
-        expect(exc.cause).to be_a(GRPC::Cancelled)
+        expect(exc.cause).to be_a(CustomException)
       end
       expect(deadline_arg).to be_a(Time)
       expect(call_count).to eq(1)


### PR DESCRIPTION
See https://github.com/googleapis/toolkit/issues/446