### PR TITLE
Revert "Ported unpack from well known types to resolve protobuf dependency error."

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'googleauth', '~> 0.5.1'
   s.add_dependency 'grpc', '~> 1.0'
   s.add_dependency 'googleapis-common-protos', '~> 1.3.1'
-  s.add_dependency 'google-protobuf', '~> 3.0.2'
+  s.add_dependency 'google-protobuf', '~> 3.1.0'
   s.add_dependency 'rly', '~> 0.2.3'
 
   s.add_development_dependency 'codecov', '~> 0.1'

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -32,6 +32,7 @@ require 'time'
 # These must be loaded separate from google/gax to avoid circular dependency.
 require 'google/gax/constants'
 require 'google/gax/settings'
+require 'google/protobuf/well_known_types'
 
 module Google
   module Gax
@@ -135,7 +136,7 @@ module Google
       def results
         return nil unless done?
         return @grpc_op.error if error?
-        unpack(@grpc_op.response, @result_type)
+        @grpc_op.response.unpack(@result_type)
       end
 
       # Returns the metadata of an operation. If a type is provided,
@@ -150,7 +151,7 @@ module Google
       #   The metadata of the operation. Can be nil.
       def metadata
         return nil if @grpc_op.metadata.nil?
-        unpack(@grpc_op.metadata, @metadata_type)
+        @grpc_op.metadata.unpack(@metadata_type)
       end
 
       # Checks if the operation is done. This does not send a new api call,
@@ -238,16 +239,6 @@ module Google
           @callbacks.push(block)
         end
       end
-
-      # TODO: This is from google/protobuf/well_known_types.rb.
-      # Using google/protobuf in gax-ruby is currently causing a dependency
-      # conflict with grpc. When grpc depends on google-protobuf v3.1.0
-      # remove this function and use Google::Protobuf::Any#unpack.
-      def unpack(any_pb, klass)
-        type_name = any_pb.type_url.split('/')[-1]
-        return klass.decode(any_pb.value) if type_name == klass.descriptor.name
-      end
-      private :unpack
     end
   end
 end

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -33,6 +33,7 @@ require 'google/gax/operation'
 require 'google/gax/settings'
 require 'google/gax/constants'
 require 'google/protobuf/any_pb'
+require 'google/protobuf/well_known_types'
 require 'google/rpc/status_pb'
 require 'google/longrunning/operations_pb'
 
@@ -56,26 +57,13 @@ class MockLroClient
   end
 end
 
-# TODO: This is from google/protobuf/well_known_types.rb.
-# Using google/protobuf in gax-ruby is currently causing a dependency
-# conflict with grpc. When grpc depends on google-protobuf v3.1.0
-# remove this function and use Google::Protobuf::Any#pack.
-def pack(any_pb, msg, type_url_prefix = 'type.googleapis.com/')
-  if type_url_prefix.empty? || type_url_prefix[-1] != '/'
-    any_pb.type_url = "#{type_url_prefix}/#{msg.class.descriptor.name}"
-  else
-    any_pb.type_url = "#{type_url_prefix}#{msg.class.descriptor.name}"
-  end
-  any_pb.value = msg.to_proto
-end
-
 RESULT_ANY = Google::Protobuf::Any.new
 RESULT = Google::Rpc::Status.new(code: 1, message: 'Result')
-pack(RESULT_ANY, RESULT)
+RESULT_ANY.pack(RESULT)
 
 METADATA_ANY = Google::Protobuf::Any.new
 METADATA = Google::Rpc::Status.new(code: 2, message: 'Metadata')
-pack(METADATA_ANY, METADATA)
+METADATA_ANY.pack(METADATA)
 
 DONE_GET_METHOD = proc do
   GrpcOp.new(done: true, response: RESULT_ANY, metadata: METADATA_ANY)


### PR DESCRIPTION
Reverts googleapis/gax-ruby#53

Looks like a rubocop error. Looking into it.