### PR TITLE
Add Operation methods

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'googleauth', '~> 0.5.1'
   s.add_dependency 'grpc', '~> 1.0'
-  s.add_dependency 'googleapis-common-protos', '~> 1.3.1'
+  s.add_dependency 'googleapis-common-protos', '~> 1.3.5'
   s.add_dependency 'google-protobuf', '~> 3.2'
   s.add_dependency 'rly', '~> 0.2.3'
 

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -175,6 +175,11 @@ module Google
         @client.cancel_operation(@grpc_op.name)
       end
 
+      # Deletes the operation.
+      def delete
+        @client.delete_operation(@grpc_op.name)
+      end
+
       # Reloads the operation object.
       #
       # @return [Google::Gax::Operation]

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -135,7 +135,7 @@ module Google
       #   will be returned.
       def results
         return nil unless done?
-        return @grpc_op.error if error?
+        return error if error?
         @grpc_op.response.unpack(@result_type)
       end
 
@@ -168,6 +168,15 @@ module Google
       # @return [Boolean] Whether an error has been returned.
       def error?
         done? ? @grpc_op.result == :error : false
+      end
+
+      # If the operation response is an error, the error will be returned,
+      # otherwise returns nil.
+      #
+      # @return [Google::Rpc::Status, nil]
+      #   The error object.
+      def error
+        @grpc_op.error if error?
       end
 
       # Cancels the operation.

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -121,22 +121,16 @@ module Google
         @callbacks = []
       end
 
-      # If the operation is done, returns the result, otherwise returns nil.
+      # If the operation is done, returns the response.
       # If the operation response is an error, the error will be returned.
-      # If a type is provided, the response will be unpacked using the type
-      # provided; returning nil if the response is not of the type provided.
-      # If the type is not of provided, the response will be unpacked using
-      # the response's type_url if the type_url is found in the
-      # Google::Protobuf::DescriptorPool.generated_pool.
-      # If the type cannot be found the raw response is retuned.
+      # Otherwise returns nil.
       #
       # @return [Object, Google::Rpc::Status, nil]
       #   The result of the operation. If it is an error a Google::Rpc::Status
       #   will be returned.
       def results
-        return nil unless done?
         return error if error?
-        @grpc_op.response.unpack(@result_type)
+        return response if response?
       end
 
       # Returns the metadata of an operation. If a type is provided,
@@ -160,6 +154,22 @@ module Google
       # @return [Boolean] Whether the operation is done.
       def done?
         @grpc_op.done
+      end
+
+      # Checks if the operation is done and the result is a response.
+      # If the operation is not finished then this will return false.
+      #
+      # @return [Boolean] Whether a response has been returned.
+      def response?
+        done? ? @grpc_op.result == :response : false
+      end
+
+      # If the operation is done, returns the response, otherwise returns nil.
+      #
+      # @return [Object, nil]
+      #   The response of the operation.
+      def response
+        @grpc_op.response.unpack(@result_type) if response?
       end
 
       # Checks if the operation is done and the result is an error.

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -133,6 +133,17 @@ module Google
         return response if response?
       end
 
+      # Returns the server-assigned name of the operation, which is only unique
+      # within the same service that originally returns it. If you use the
+      # default HTTP mapping, the name should have the format of
+      # operations/some/unique/name.
+      #
+      # @return [String]
+      #   The name of the operation.
+      def name
+        @grpc_op.name
+      end
+
       # Returns the metadata of an operation. If a type is provided,
       # the metadata will be unpacked using the type provided; returning nil
       # if the metadata is not of the type provided.

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.7.1'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -153,6 +153,41 @@ describe Google::Gax::Operation do
     end
   end
 
+  context 'method `response?`' do
+    it 'should return false on unfinished operation.' do
+      expect(create_op(GrpcOp.new(done: false)).response?).to eq(false)
+    end
+
+    it 'should return false on error operation.' do
+      error = Google::Rpc::Status.new
+      op = create_op(GrpcOp.new(done: true, error: error))
+      expect(op.response?).to eq(false)
+    end
+
+    it 'should return true on finished operation.' do
+      op = create_op(GrpcOp.new(done: true, response: RESULT_ANY))
+      expect(op.response?).to eq(true)
+    end
+  end
+
+  context 'method `response`' do
+    it 'should return nil on unfinished operation.' do
+      op = create_op(GrpcOp.new(done: false))
+      expect(op.response).to eq(nil)
+    end
+
+    it 'should return nil on error operation.' do
+      error = Google::Rpc::Status.new
+      op = create_op(GrpcOp.new(done: true, error: error))
+      expect(op.response).to eq(nil)
+    end
+
+    it 'should result on finished operation.' do
+      op = create_op(GrpcOp.new(done: true, response: RESULT_ANY))
+      expect(op.response).to eq(RESULT)
+    end
+  end
+
   context 'method `cancel`' do
     it 'should call the clients cancel_operation' do
       op_name = 'test_name'

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -43,9 +43,10 @@ GaxOp = Google::Gax::Operation
 MILLIS_PER_SECOND = Google::Gax::MILLIS_PER_SECOND
 
 class MockLroClient
-  def initialize(get_method: nil, cancel_method: nil)
+  def initialize(get_method: nil, cancel_method: nil, delete_method: nil)
     @get_method = get_method
     @cancel_method = cancel_method
+    @delete_method = delete_method
   end
 
   def get_operation(grpc_method, options: nil)
@@ -54,6 +55,10 @@ class MockLroClient
 
   def cancel_operation(name)
     @cancel_method.call(name)
+  end
+
+  def delete_operation(name)
+    @delete_method.call(name)
   end
 end
 
@@ -140,6 +145,20 @@ describe Google::Gax::Operation do
       end
       mock_client = MockLroClient.new(cancel_method: cancel_method)
       create_op(GrpcOp.new(name: op_name), client: mock_client).cancel
+      expect(called).to eq(true)
+    end
+  end
+
+  context 'method `delete`' do
+    it 'should call the clients delete_operation' do
+      op_name = 'test_name'
+      called = false
+      delete_method = proc do |name|
+        expect(name).to eq(op_name)
+        called = true
+      end
+      mock_client = MockLroClient.new(delete_method: delete_method)
+      create_op(GrpcOp.new(name: op_name), client: mock_client).delete
       expect(called).to eq(true)
     end
   end

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -104,6 +104,13 @@ describe Google::Gax::Operation do
     end
   end
 
+  context 'method `name`' do
+    it 'should return the operation name' do
+      op = create_op(GrpcOp.new(done: true, name: '1234567890'))
+      expect(op.name).to eq('1234567890')
+    end
+  end
+
   context 'method `metadata`' do
     it 'should unpack the metadata' do
       op = create_op(GrpcOp.new(done: true, metadata: METADATA_ANY))

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -129,9 +129,27 @@ describe Google::Gax::Operation do
       expect(op.error?).to eq(true)
     end
 
-    it 'should return true on finished operation.' do
+    it 'should return false on finished operation.' do
       op = create_op(GrpcOp.new(done: true, response: RESULT_ANY))
       expect(op.error?).to eq(false)
+    end
+  end
+
+  context 'method `error`' do
+    it 'should return nil on unfinished operation.' do
+      op = create_op(GrpcOp.new(done: false))
+      expect(op.error).to eq(nil)
+    end
+
+    it 'should return error on error operation.' do
+      error = Google::Rpc::Status.new
+      op = create_op(GrpcOp.new(done: true, error: error))
+      expect(op.error).to eq(error)
+    end
+
+    it 'should return nil on finished operation.' do
+      op = create_op(GrpcOp.new(done: true, response: RESULT_ANY))
+      expect(op.error).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Add the following methods to `Google::Gax::Operation`:

* `#name`
* `#error`
* `#response?`
* `#response`
* `#delete`