### PR TITLE
Update LRO headers to use generated ruby version.

### DIFF
--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -107,7 +107,7 @@ module Google
 
         google_api_client = "gl-ruby/#{RUBY_VERSION}"
         google_api_client << " #{lib_name}/#{lib_version}" if lib_name
-        google_api_client << " gapic/ gax/#{Google::Gax::VERSION}"
+        google_api_client << " gapic/0.6.8 gax/#{Google::Gax::VERSION}"
         google_api_client << " grpc/#{GRPC::VERSION}"
         google_api_client.freeze
 


### PR DESCRIPTION
Uses generated ruby version here: https://github.com/googleapis/googleapis/blob/master/gapic/packaging/api_defaults.yaml#L35