### PR TITLE
Port credentials class from google-cloud-core

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,6 +19,11 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Max: 9
 
+# Offense count: 2
+Metrics/LineLength:
+  Exclude:
+    - 'spec/google/gax/credentials_spec.rb'
+
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/lib/google/gax.rb
+++ b/lib/google/gax.rb
@@ -29,6 +29,7 @@
 
 require 'google/gax/api_callable'
 require 'google/gax/constants'
+require 'google/gax/credentials'
 require 'google/gax/errors'
 require 'google/gax/path_template'
 require 'google/gax/settings'

--- a/lib/google/gax/credentials.rb
+++ b/lib/google/gax/credentials.rb
@@ -111,9 +111,8 @@ module Google
 
       # Verify that the keyfile argument is provided.
       def verify_keyfile_provided!(keyfile)
-        if keyfile.nil?
-          raise 'The keyfile passed to Google::Gax::Credentials.new was nil.'
-        end
+        return unless keyfile.nil?
+        raise 'The keyfile passed to Google::Gax::Credentials.new was nil.'
       end
 
       # Verify that the keyfile argument is a file.

--- a/lib/google/gax/credentials.rb
+++ b/lib/google/gax/credentials.rb
@@ -1,0 +1,149 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'forwardable'
+require 'googleauth'
+require 'json'
+require 'signet/oauth_2/client'
+
+module Google
+  module Gax
+    # @private
+    # Represents the OAuth 2.0 signing logic.
+    # This class is intended to be inherited by API-specific classes
+    # which overrides the SCOPE constant.
+    class Credentials
+      TOKEN_CREDENTIAL_URI = 'https://accounts.google.com/o/oauth2/token'.freeze
+      AUDIENCE = 'https://accounts.google.com/o/oauth2/token'.freeze
+      SCOPE = [].freeze
+      PATH_ENV_VARS = [].freeze
+      JSON_ENV_VARS = [].freeze
+      DEFAULT_PATHS = [].freeze
+
+      attr_accessor :client
+
+      ##
+      # Delegate client methods to the client object.
+      extend Forwardable
+      def_delegators :@client,
+                     :token_credential_uri, :audience,
+                     :scope, :issuer, :signing_key, :updater_proc
+
+      def initialize(keyfile, scope: nil)
+        verify_keyfile_provided! keyfile
+        if keyfile.is_a? Signet::OAuth2::Client
+          @client = keyfile
+        elsif keyfile.is_a? Hash
+          hash = stringify_hash_keys keyfile
+          hash['scope'] ||= scope
+          @client = init_client hash
+        else
+          verify_keyfile_exists! keyfile
+          json = JSON.parse ::File.read(keyfile)
+          json['scope'] ||= scope
+          @client = init_client json
+        end
+        @client.fetch_access_token!
+      end
+
+      ##
+      # Returns the default credentials.
+      #
+      def self.default(scope: nil)
+        env = ->(v) { ENV[v] }
+        json = lambda do |v|
+          unless ENV[v].nil?
+            begin
+              JSON.parse ENV[v]
+            rescue
+              nil
+            end
+          end
+        end
+        path = ->(p) { ::File.file? p }
+
+        # First try to find keyfile file from environment variables.
+        self::PATH_ENV_VARS.map(&env).compact.select(&path)
+                           .each do |file|
+          return new file, scope: scope
+        end
+        # Second try to find keyfile json from environment variables.
+        self::JSON_ENV_VARS.map(&json).compact.each do |hash|
+          return new hash, scope: scope
+        end
+        # Third try to find keyfile file from known file paths.
+        self::DEFAULT_PATHS.select(&path).each do |file|
+          return new file, scope: scope
+        end
+        # Finally get instantiated client from Google::Auth.
+        scope ||= self::SCOPE
+        client = Google::Auth.get_application_default scope
+        new client
+      end
+
+      protected
+
+      # Verify that the keyfile argument is provided.
+      def verify_keyfile_provided!(keyfile)
+        raise 'You must provide a keyfile to connect with.' if keyfile.nil?
+      end
+
+      # Verify that the keyfile argument is a file.
+      def verify_keyfile_exists!(keyfile)
+        exists = ::File.file? keyfile
+        raise "The keyfile '#{keyfile}' is not a valid file." unless exists
+      end
+
+      # Initializes the Signet client.
+      def init_client(keyfile)
+        client_opts = client_options keyfile
+        Signet::OAuth2::Client.new client_opts
+      end
+
+      # returns a new Hash with string keys instead of symbol keys.
+      def stringify_hash_keys(hash)
+        Hash[hash.map { |k, v| [k.to_s, v] }]
+      end
+
+      def client_options(options)
+        # Keyfile options have higher priority over constructor defaults
+        options['token_credential_uri'] ||= self.class::TOKEN_CREDENTIAL_URI
+        options['audience'] ||= self.class::AUDIENCE
+        options['scope'] ||= self.class::SCOPE
+
+        # client options for initializing signet client
+        { token_credential_uri: options['token_credential_uri'],
+          audience: options['audience'],
+          scope: Array(options['scope']),
+          issuer: options['client_email'],
+          signing_key: OpenSSL::PKey::RSA.new(options['private_key']) }
+      end
+    end
+  end
+end

--- a/lib/google/gax/credentials.rb
+++ b/lib/google/gax/credentials.rb
@@ -111,7 +111,9 @@ module Google
 
       # Verify that the keyfile argument is provided.
       def verify_keyfile_provided!(keyfile)
-        raise 'You must provide a keyfile to connect with.' if keyfile.nil?
+        if keyfile.nil?
+          raise 'The keyfile passed to Google::Gax::Credentials.new was nil.'
+        end
       end
 
       # Verify that the keyfile argument is a file.

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.8.4'.freeze
+    VERSION = '0.8.5'.freeze
   end
 end

--- a/spec/google/gax/credentials_spec.rb
+++ b/spec/google/gax/credentials_spec.rb
@@ -1,0 +1,77 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'google/gax/credentials'
+
+# This test is testing the private class Google::Gax::Credentials. We want to
+# make sure that the passed in scope propogates to the Signet object. This means
+# testing the private API, which is generally frowned on.
+describe Google::Gax::Credentials, :private do
+  let(:default_keyfile_hash) do
+    {
+      'private_key_id' => 'testabc1234567890xyz',
+      'private_key' => "-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAOyi0Hy1l4Ym2m2o71Q0TF4O9E81isZEsX0bb+Bqz1SXEaSxLiXM\nUZE8wu0eEXivXuZg6QVCW/5l+f2+9UPrdNUCAwEAAQJAJkqubA/Chj3RSL92guy3\nktzeodarLyw8gF8pOmpuRGSiEo/OLTeRUMKKD1/kX4f9sxf3qDhB4e7dulXR1co/\nIQIhAPx8kMW4XTTL6lJYd2K5GrH8uBMp8qL5ya3/XHrBgw3dAiEA7+3Iw3ULTn2I\n1J34WlJ2D5fbzMzB4FAHUNEV7Ys3f1kCIQDtUahCMChrl7+H5t9QS+xrn77lRGhs\nB50pjvy95WXpgQIhAI2joW6JzTfz8fAapb+kiJ/h9Vcs1ZN3iyoRlNFb61JZAiA8\nNy5NyNrMVwtB/lfJf1dAK/p/Bwd8LZLtgM6PapRfgw==\n-----END RSA PRIVATE KEY-----\n",
+      'client_email' => 'credz-testabc1234567890xyz@developer.gserviceaccount.com',
+      'client_id' => 'credz-testabc1234567890xyz.apps.googleusercontent.com',
+      'type' => 'service_account'
+    }
+  end
+
+  it 'uses a default scope' do
+    mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+    allow(Signet::OAuth2::Client).to receive(:new) do |options|
+      expect(options[:token_credential_uri]).to eq('https://accounts.google.com/o/oauth2/token')
+      expect(options[:audience]).to eq('https://accounts.google.com/o/oauth2/token')
+      expect(options[:scope]).to eq([])
+      expect(options[:issuer]).to eq(default_keyfile_hash['client_email'])
+      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+      mocked_signet
+    end
+
+    Google::Gax::Credentials.new default_keyfile_hash
+  end
+
+  it 'uses a custom scope' do
+    mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+    allow(Signet::OAuth2::Client).to receive(:new) do |options|
+      expect(options[:token_credential_uri]).to eq('https://accounts.google.com/o/oauth2/token')
+      expect(options[:audience]).to eq('https://accounts.google.com/o/oauth2/token')
+      expect(options[:scope]).to eq(['http://example.com/scope'])
+      expect(options[:issuer]).to eq(default_keyfile_hash['client_email'])
+      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+      mocked_signet
+    end
+
+    Google::Gax::Credentials.new default_keyfile_hash, scope: 'http://example.com/scope'
+  end
+end

--- a/spec/google/gax/credentials_spec.rb
+++ b/spec/google/gax/credentials_spec.rb
@@ -76,17 +76,17 @@ describe Google::Gax::Credentials, :private do
   end
 
   it 'can be subclassed to pass in other env paths' do
-    TEST_PATH_ENV_VAR = "TEST_PATH"
-    TEST_PATH_ENV_VAL = "/unknown/path/to/file.txt"
-    TEST_JSON_ENV_VAR = "TEST_JSON_VARS"
+    TEST_PATH_ENV_VAR = 'TEST_PATH'.freeze
+    TEST_PATH_ENV_VAL = '/unknown/path/to/file.txt'.freeze
+    TEST_JSON_ENV_VAR = 'TEST_JSON_VARS'.freeze
 
     ENV[TEST_PATH_ENV_VAR] = TEST_PATH_ENV_VAL
     ENV[TEST_JSON_ENV_VAR] = JSON.generate(default_keyfile_hash)
 
     class TestCredentials < Google::Gax::Credentials
-      SCOPE = 'http://example.com/scope'
-      PATH_ENV_VARS = [TEST_PATH_ENV_VAR]
-      JSON_ENV_VARS = [TEST_JSON_ENV_VAR]
+      SCOPE = 'http://example.com/scope'.freeze
+      PATH_ENV_VARS = [TEST_PATH_ENV_VAR].freeze
+      JSON_ENV_VARS = [TEST_JSON_ENV_VAR].freeze
     end
 
     allow(::File).to receive(:file?).with(TEST_PATH_ENV_VAL) { false }

--- a/spec/google/gax/grpc_spec.rb
+++ b/spec/google/gax/grpc_spec.rb
@@ -1,0 +1,117 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'google/gax/grpc'
+
+describe Google::Gax::Grpc do
+  describe '#create_stub' do
+    it 'yields constructed channel credentials' do
+      mock = instance_double(GRPC::Core::ChannelCredentials)
+      composed_mock = instance_double(GRPC::Core::ChannelCredentials)
+      default_creds = instance_double(Google::Auth::ServiceAccountCredentials)
+      updater_proc = proc {}
+
+      allow(Google::Auth)
+        .to receive(:get_application_default).and_return(default_creds)
+      allow(default_creds).to receive(:updater_proc).and_return(updater_proc)
+      allow(mock).to receive(:compose).and_return(composed_mock)
+      allow(GRPC::Core::ChannelCredentials).to receive(:new).and_return(mock)
+
+      expect do |blk|
+        Google::Gax::Grpc.create_stub('service', 'port', &blk)
+      end.to yield_with_args('service:port', composed_mock)
+    end
+
+    it 'yields given channel' do
+      mock = instance_double(GRPC::Core::Channel)
+      expect do |blk|
+        Google::Gax::Grpc.create_stub('service', 'port', channel: mock, &blk)
+      end.to yield_with_args('service:port', nil, channel_override: mock)
+    end
+
+    it 'yields given channel credentials' do
+      mock = instance_double(GRPC::Core::ChannelCredentials)
+      expect do |blk|
+        Google::Gax::Grpc.create_stub('service', 'port', chan_creds: mock, &blk)
+      end.to yield_with_args('service:port', mock)
+    end
+
+    it 'yields channel credentials composed of the given updater_proc' do
+      chan_creds = instance_double(GRPC::Core::ChannelCredentials)
+      composed_chan_creds = instance_double(GRPC::Core::ChannelCredentials)
+      call_creds = instance_double(GRPC::Core::CallCredentials)
+      updater_proc = proc {}
+
+      allow(GRPC::Core::CallCredentials)
+        .to receive(:new).with(updater_proc).and_return(call_creds)
+      allow(GRPC::Core::ChannelCredentials)
+        .to receive(:new).and_return(chan_creds)
+      allow(chan_creds)
+        .to receive(:compose).with(call_creds).and_return(composed_chan_creds)
+      expect do |blk|
+        Google::Gax::Grpc.create_stub(
+          'service', 'port', updater_proc: updater_proc, &blk
+        )
+      end.to yield_with_args('service:port', composed_chan_creds)
+    end
+
+    it 'raise an argument error if multiple creds are passed in' do
+      channel = instance_double(GRPC::Core::Channel)
+      chan_creds = instance_double(GRPC::Core::ChannelCredentials)
+      updater_proc = instance_double(Proc)
+
+      expect do |blk|
+        Google::Gax::Grpc.create_stub(
+          'service', 'port', channel: channel, chan_creds: chan_creds, &blk
+        )
+      end.to raise_error(ArgumentError)
+
+      expect do |blk|
+        Google::Gax::Grpc.create_stub(
+          'service', 'port', channel: channel,
+                             updater_proc: updater_proc, &blk
+        )
+      end.to raise_error(ArgumentError)
+
+      expect do |blk|
+        Google::Gax::Grpc.create_stub(
+          'service', 'port', chan_creds: chan_creds,
+                             updater_proc: updater_proc, &blk
+        )
+      end.to raise_error(ArgumentError)
+
+      expect do |blk|
+        Google::Gax::Grpc.create_stub(
+          'service', 'port', channel: channel, chan_creds: chan_creds,
+                             updater_proc: updater_proc, &blk
+        )
+      end.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Updates: https://github.com/googleapis/toolkit/issues/1324

#### Deviations from google-cloud-core
- added `:updater_proc` as a delegated method
- removed default gcloud paths since they don't make sense in the google-gax context
- changed the test file to use rspec instead of minitest