### PR TITLE
Set default scope for LRO client

### DIFF
--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.8.6'.freeze
+    VERSION = '0.8.7'.freeze
   end
 end

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -80,6 +80,7 @@ module Google
       # The scopes needed to make gRPC calls to all of the methods defined in
       # this service.
       ALL_SCOPES = [
+        "https://www.googleapis.com/auth/cloud-platform",
       ].freeze
 
       # @param service_path [String]
@@ -142,7 +143,7 @@ module Google
           warn "`app_name` and `app_version` are no longer being used in the request headers."
         end
 
-        credentials ||= Google::Gax::Credentials.default
+        credentials ||= Google::Gax::Credentials.default(scope: scopes)
 
         if credentials.is_a?(String) || credentials.is_a?(Hash)
           updater_proc = Google::Gax::Credentials.new(credentials).updater_proc


### PR DESCRIPTION
This is a workaround to ensure backward-compatibility with older GAPIC
clients. It will be removed in GAX 0.9.0.