### PR TITLE
Add GAX error details attribute

### DIFF
--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -29,16 +29,21 @@
 
 require 'English'
 
+require 'google/gax/grpc'
+
 module Google
   module Gax
     # Common base class for exceptions raised by GAX.
     class GaxError < StandardError
+      attr_reader :details
+
       # @param msg [String] describes the error that occurred.
       def initialize(msg)
         msg = "GaxError #{msg}"
         msg += ", caused by #{$ERROR_INFO}" if $ERROR_INFO
         super(msg)
         @cause = $ERROR_INFO
+        @details = Google::Gax::Grpc.deserialize_error_status_details(@cause)
       end
 
       # cause is a new method introduced in 2.1.0, bring this


### PR DESCRIPTION
The details attribute provides easy access to deserialized error
details. Previously, API custom error types were only accessible
by inspecting the gRPC error, and then only availabe in serialized
form.

Fixes
https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1438