### PR TITLE
GAX bug fixes

### DIFF
--- a/lib/google/gax/grpc.rb
+++ b/lib/google/gax/grpc.rb
@@ -56,8 +56,8 @@ module Google
               error.to_status
             ).details
         rescue
-          return "Could not parse error details due to a malformed server "\
-                 "response trailer."
+          return 'Could not parse error details due to a malformed server '\
+                 'response trailer.'
         end
         return if details.nil?
         details =

--- a/lib/google/gax/grpc.rb
+++ b/lib/google/gax/grpc.rb
@@ -48,21 +48,25 @@ module Google
       API_ERRORS = [GRPC::BadStatus, GRPC::Cancelled].freeze
 
       def deserialize_error_status_details(error)
-        return unless error.is_a? GRPC::BadStatus
-        details =
-          GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(
-            error.to_status
-          ).details
-        details.map do |any|
-          # If the type of the proto wrapped by the Any instance is not
-          # available, do not deserialize.
-          candidate_class_name = class_case(any.type_name.split('.')).join('::')
-          begin
-            any.unpack(Object.const_get(candidate_class_name))
-          rescue NameError
-            any
-          end
-        end
+        # TODO (geigerj): Uncomment once https://github.com/grpc/grpc/pull/12721
+        # is released.
+        #
+        #
+        # return unless error.is_a? GRPC::BadStatus
+        # details =
+        #   GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(
+        #     error.to_status
+        #   ).details
+        # details.map do |any|
+        #   # If the type of the proto wrapped by the Any instance is not
+        #   # available, do not deserialize.
+        #   candidate_class_name = class_case(any.type_name.split('.')).join('::')
+        #   begin
+        #     any.unpack(Object.const_get(candidate_class_name))
+        #   rescue NameError
+        #     any
+        #   end
+        # end
       end
 
       # rubocop:disable Metrics/ParameterLists

--- a/lib/google/gax/util.rb
+++ b/lib/google/gax/util.rb
@@ -42,12 +42,15 @@ module Google
     # messages using hashes but does not allow for nested hashes to instantiate
     # nested submessages.
     #
-    # @param hash [Hash] The hash to be converted into a proto message.
+    # @param hash [Hash || Class] The hash to be converted into a proto message.
+    #   If an instance of the proto message class is given, it is returned
+    #   unchanged.
     # @param message_class [Class] The corresponding protobuf message class of
     #   the given hash.
     #
     # @return [Object] An instance of the given message class.
     def to_proto(hash, message_class)
+      return hash if hash.is_a? message_class
       hash = coerce_submessages(hash, message_class)
       message_class.new(hash)
     end

--- a/lib/google/gax/util.rb
+++ b/lib/google/gax/util.rb
@@ -51,6 +51,12 @@ module Google
     # @return [Object] An instance of the given message class.
     def to_proto(hash, message_class)
       return hash if hash.is_a? message_class
+
+      # Sanity check: input must be a Hash
+      unless hash.is_a? Hash
+        raise ArgumentError,
+              "Value #{hash.to_s} must be a Hash or a #{message_class.name}"
+      end
       hash = coerce_submessages(hash, message_class)
       message_class.new(hash)
     end

--- a/lib/google/gax/util.rb
+++ b/lib/google/gax/util.rb
@@ -55,7 +55,7 @@ module Google
       # Sanity check: input must be a Hash
       unless hash.is_a? Hash
         raise ArgumentError,
-              "Value #{hash.to_s} must be a Hash or a #{message_class.name}"
+              "Value #{hash} must be a Hash or a #{message_class.name}"
       end
       hash = coerce_submessages(hash, message_class)
       message_class.new(hash)

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.8.8'.freeze
+    VERSION = '0.8.11'.freeze
   end
 end

--- a/spec/google/gax/grpc_spec.rb
+++ b/spec/google/gax/grpc_spec.rb
@@ -115,7 +115,7 @@ describe Google::Gax::Grpc do
     end
   end
   describe '#deserialize_error_status_details' do
-    it 'deserializes a known error type' do
+    skip 'deserializes a known error type' do
       expected_error = Google::Rpc::DebugInfo.new(detail: 'shoes are untied')
 
       any = Google::Protobuf::Any.new
@@ -130,7 +130,7 @@ describe Google::Gax::Grpc do
       expect(Google::Gax::Grpc.deserialize_error_status_details(error))
         .to eq [expected_error]
     end
-    it 'does not deserialize an unknown error type' do
+    skip 'does not deserialize an unknown error type' do
       expected_error = Random.new.bytes(8)
 
       any = Google::Protobuf::Any.new(

--- a/spec/google/gax/grpc_spec.rb
+++ b/spec/google/gax/grpc_spec.rb
@@ -115,7 +115,7 @@ describe Google::Gax::Grpc do
     end
   end
   describe '#deserialize_error_status_details' do
-    skip 'deserializes a known error type' do
+    it 'deserializes a known error type' do
       expected_error = Google::Rpc::DebugInfo.new(detail: 'shoes are untied')
 
       any = Google::Protobuf::Any.new
@@ -130,7 +130,7 @@ describe Google::Gax::Grpc do
       expect(Google::Gax::Grpc.deserialize_error_status_details(error))
         .to eq [expected_error]
     end
-    skip 'does not deserialize an unknown error type' do
+    it 'does not deserialize an unknown error type' do
       expected_error = Random.new.bytes(8)
 
       any = Google::Protobuf::Any.new(

--- a/spec/google/gax/util_spec.rb
+++ b/spec/google/gax/util_spec.rb
@@ -134,6 +134,5 @@ describe Google::Gax do
         Google::Gax.to_proto(user_message, Google::Protobuf::User)
       end.to raise_error(ArgumentError)
     end
-
   end
 end

--- a/spec/google/gax/util_spec.rb
+++ b/spec/google/gax/util_spec.rb
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'google/gax'
+require 'google/protobuf/any_pb'
 require 'spec/fixtures/fixture_pb'
 
 describe Google::Gax do
@@ -118,5 +119,21 @@ describe Google::Gax do
         Google::Gax.to_proto(user_hash, Google::Protobuf::User)
       end.to raise_error(ArgumentError)
     end
+
+    it 'handles proto messages' do
+      user_message = Google::Protobuf::User.new(
+        name: USER_NAME, type: USER_TYPE
+      )
+      user = Google::Gax.to_proto(user_message, Google::Protobuf::User)
+      expect(user).to eq user_message
+    end
+
+    it 'fails if proto message has unexpected type' do
+      user_message = Google::Protobuf::Any
+      expect do
+        Google::Gax.to_proto(user_message, Google::Protobuf::User)
+      end.to raise_error(ArgumentError)
+    end
+
   end
 end


### PR DESCRIPTION
- Disables error detail deserialization until a fix in gRPC is released.
- Allows instances of proto messages to be passed to to_proto
- Bump version. Note that non-sequential increase is due to rollbacks