### PR TITLE
Specify correct gRPC dependency

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'googleauth', '~> 0.5.1'
-  s.add_dependency 'grpc', '~> 1.0'
+  s.add_dependency 'grpc', '~> 1.6.6'
   s.add_dependency 'googleapis-common-protos', '~> 1.3.5'
   s.add_dependency 'google-protobuf', '~> 3.2'
   s.add_dependency 'rly', '~> 0.2.3'

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.8.11'.freeze
+    VERSION = '0.8.12'.freeze
   end
 end


### PR DESCRIPTION
Previously, GAX depended on features only introduced in gRPC `1.6.2` and `1.6.6`.