### PR TITLE
Remove warning from service port.

### DIFF
--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.9.1'.freeze
+    VERSION = '0.9.2'.freeze
   end
 end

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -132,8 +132,8 @@ module Google
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
-          warn "`service_path` and `port` parameters are deprecated and will be removed"
+        if port != DEFAULT_SERVICE_PORT
+          warn "the `port` parameter is deprecated and will be removed"
         end
 
         credentials ||= Google::Auth::Credentials.default(scopes: scopes)


### PR DESCRIPTION
The "correct" fix for this will be to have GAPICs that rely on LRO
override the service path attribute, rather than passing it in to
the constructor. But we need to continue supporting the constructor
argument without warning until that can be done.

Fixes #102