### PR TITLE
GaxError presents BadStatus values

### DIFF
--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -35,7 +35,7 @@ module Google
   module Gax
     # Common base class for exceptions raised by GAX.
     class GaxError < StandardError
-      attr_reader :details
+      attr_reader :status_details
 
       # @param msg [String] describes the error that occurred.
       def initialize(msg)
@@ -43,7 +43,8 @@ module Google
         msg += ", caused by #{$ERROR_INFO}" if $ERROR_INFO
         super(msg)
         @cause = $ERROR_INFO
-        @details = Google::Gax::Grpc.deserialize_error_status_details(@cause)
+        @status_details = \
+          Google::Gax::Grpc.deserialize_error_status_details(@cause)
       end
 
       # cause is a new method introduced in 2.1.0, bring this

--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -54,6 +54,21 @@ module Google
           @cause
         end
       end
+
+      def code
+        return nil unless cause && cause.respond_to?(:code)
+        cause.code
+      end
+
+      def details
+        return nil unless cause && cause.respond_to?(:details)
+        cause.details
+      end
+
+      def metadata
+        return nil unless cause && cause.respond_to?(:metadata)
+        cause.metadata
+      end
     end
 
     # Indicates an error during automatic GAX retrying.

--- a/spec/google/gax/error_spec.rb
+++ b/spec/google/gax/error_spec.rb
@@ -1,0 +1,141 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'google/gax/errors'
+require 'google/protobuf/any_pb'
+require 'spec/fixtures/fixture_pb'
+
+describe Google::Gax::GaxError do
+  describe 'without cause' do
+    it 'presents GRPC::BadStatus values' do
+      error = Google::Gax::GaxError.new('no cause')
+
+      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error.message).to eq('GaxError no cause')
+      expect(error.code).to be_nil
+      expect(error.details).to be_nil
+      expect(error.metadata).to be_nil
+      expect(error.status_details).to be_nil
+
+      expect(error.cause).to be_nil
+    end
+  end
+
+  describe 'with cause as RuntimeError' do
+    it 'presents GRPC::BadStatus values' do
+      error = wrapped_error('not allowed')
+
+      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error.message).to eq('GaxError not allowed, caused by not allowed')
+      expect(error.code).to be_nil
+      expect(error.details).to be_nil
+      expect(error.metadata).to be_nil
+      expect(error.status_details).to be_nil
+
+      expect(error.cause).to be_an_instance_of(RuntimeError)
+      expect(error.cause.message).to eq('not allowed')
+    end
+  end
+
+  describe 'with cause as GRPC::BadStatus' do
+    it 'presents GRPC::BadStatus values' do
+      error = wrapped_badstatus(3, 'invalid')
+
+      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error.message).to eq('GaxError 3:invalid, caused by 3:invalid')
+      expect(error.code).to eq(3)
+      expect(error.details).to eq('invalid')
+      expect(error.metadata).to eq({})
+      expect(error.status_details).to eq(
+        'Could not parse error details due to a ' \
+        'malformed server response trailer.'
+      )
+
+      expect(error.cause).to be_an_instance_of(GRPC::BadStatus)
+      expect(error.cause.message).to eq('3:invalid')
+      expect(error.cause.code).to eq(3)
+      expect(error.cause.details).to eq('invalid')
+      expect(error.cause.metadata).to eq({})
+    end
+  end
+
+  describe 'with cause as GRPC::BadStatus with status_detail' do
+    it 'presents GRPC::BadStatus values' do
+      status_detail = debug_info('hello world')
+      encoded_status_detail = encoded_protobuf(status_detail)
+      metadata = { 'foo' => 'bar',
+                   'grpc-status-details-bin' => encoded_status_detail }
+      error = wrapped_badstatus(1, 'cancelled', metadata)
+
+      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error.message).to eq('GaxError 1:cancelled, caused by 1:cancelled')
+      expect(error.code).to eq(1)
+      expect(error.details).to eq('cancelled')
+      expect(error.metadata).to eq(metadata)
+      expect(error.status_details).to eq([status_detail])
+
+      expect(error.cause).to be_an_instance_of(GRPC::BadStatus)
+      expect(error.cause.message).to eq('1:cancelled')
+      expect(error.cause.code).to eq(1)
+      expect(error.cause.details).to eq('cancelled')
+      expect(error.cause.metadata).to eq(metadata)
+    end
+  end
+
+  def wrap_with_gax_error(err)
+    raise err
+  rescue => e
+    raise Google::Gax::GaxError, e.message
+  end
+
+  def wrapped_error(msg)
+    wrap_with_gax_error(RuntimeError.new(msg))
+  rescue => gax_err
+    return gax_err
+  end
+
+  def debug_info(detail)
+    Google::Rpc::DebugInfo.new(detail: detail)
+  end
+
+  def encoded_protobuf(debug_info)
+    any = Google::Protobuf::Any.new
+    any.pack debug_info
+
+    Google::Rpc::Status.encode(
+      Google::Rpc::Status.new(details: [any])
+    )
+  end
+
+  def wrapped_badstatus(status, msg, metadata = {})
+    wrap_with_gax_error(GRPC::BadStatus.new(status, msg, metadata))
+  rescue => gax_err
+    return gax_err
+  end
+end


### PR DESCRIPTION
This PR relays the underlying BadStatus values `code`, `details`, and `metadata` without resorting to dynamic hackery using `method_missing`. If the underlying error object does not have values, or is not a BadStatus, `nil` is returned.

[refs GoogleCloudPlatform/google-cloud-ruby#1791]
[refs GoogleCloudPlatform/google-cloud-ruby#1825]