### PR TITLE
Allow operations client to be subclassed

### DIFF
--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '0.10.1'.freeze
+    VERSION = '0.10.2'.freeze
   end
 end

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -108,8 +108,8 @@ module Google
       # @param timeout [Numeric]
       #   The default timeout, in seconds, for calls made through this client.
       def initialize \
-          service_path: SERVICE_ADDRESS,
-          port: DEFAULT_SERVICE_PORT,
+          service_path: self.class::SERVICE_ADDRESS,
+          port: self.class::DEFAULT_SERVICE_PORT,
           channel: nil,
           chan_creds: nil,
           updater_proc: nil,


### PR DESCRIPTION
Note: this is hand-edited for now to preserve compatibility with older
GAPIC clients that set the service address through the ctor. We will
refresh the LRO codegen entirely for the 1.0 release.