### PR TITLE
Create Errors subclasses analogous to google-cloud-core

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,6 @@
 inherit_from: .rubocop_todo.yml
+
+# Prefer compact style, as Ruby runtime overwrites the GAX error message
+# when exploded exception style is used.
+Style/RaiseArgs:
+  EnforcedStyle: compact

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,13 +38,14 @@ Metrics/BlockLength:
     - "**/*_spec.rb"
   Max: 26
 
-# Offense count: 2
+# Offense count: 3
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/google/gax/api_callable.rb'
     - 'lib/google/gax/settings.rb'
+    - 'lib/google/gax/errors.rb'
 
 # Offense count: 5
 Style/StructInheritance:

--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -138,12 +138,12 @@ module Google
     def self.grpc_error_class_for(grpc_error_code)
       # The gRPC status code 0 is for a successful response.
       # So there is no error subclass for a 0 status code, use current class.
-      [self, CanceledError, UnknownError, InvalidArgumentError,
+      [GaxError, CanceledError, UnknownError, InvalidArgumentError,
        DeadlineExceededError, NotFoundError, AlreadyExistsError,
        PermissionDeniedError, ResourceExhaustedError, FailedPreconditionError,
        AbortedError, OutOfRangeError, UnimplementedError, InternalError,
        UnavailableError, DataLossError,
-       UnauthenticatedError][grpc_error_code] || self
+       UnauthenticatedError][grpc_error_code] || GaxError
     end
 
     module_function :from_error

--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -71,8 +71,81 @@ module Google
       end
     end
 
+    def from_error(error)
+      if error.respond_to? :code
+        grpc_error_class_for error.code
+      else
+        GaxError
+      end
+    end
+
     # Indicates an error during automatic GAX retrying.
     class RetryError < GaxError
     end
+
+    # Errors corresponding to standard HTTP/gRPC statuses.
+    class CanceledError < GaxError
+    end
+
+    class UnknownError < GaxError
+    end
+
+    class InvalidArgumentError < GaxError
+    end
+
+    class DeadlineExceededError < GaxError
+    end
+
+    class NotFoundError < GaxError
+    end
+
+    class AlreadyExistsError < GaxError
+    end
+
+    class PermissionDeniedError < GaxError
+    end
+
+    class ResourceExhaustedError < GaxError
+    end
+
+    class FailedPreconditionError < GaxError
+    end
+
+    class AbortedError < GaxError
+    end
+
+    class OutOfRangeError < GaxError
+    end
+
+    class UnimplementedError < GaxError
+    end
+
+    class InternalError < GaxError
+    end
+
+    class UnavailableError < GaxError
+    end
+
+    class DataLossError < GaxError
+    end
+
+    class UnauthenticatedError < GaxError
+    end
+
+    # @private Identify the subclass for a gRPC error
+    # Note: ported from
+    # https:/g/github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-core/lib/google/cloud/errors.rb
+    def self.grpc_error_class_for(grpc_error_code)
+      # The gRPC status code 0 is for a successful response.
+      # So there is no error subclass for a 0 status code, use current class.
+      [self, CanceledError, UnknownError, InvalidArgumentError,
+       DeadlineExceededError, NotFoundError, AlreadyExistsError,
+       PermissionDeniedError, ResourceExhaustedError, FailedPreconditionError,
+       AbortedError, OutOfRangeError, UnimplementedError, InternalError,
+       UnavailableError, DataLossError,
+       UnauthenticatedError][grpc_error_code] || self
+    end
+
+    module_function :from_error
   end
 end

--- a/lib/google/gax/grpc.rb
+++ b/lib/google/gax/grpc.rb
@@ -136,9 +136,9 @@ module Google
         if (channel && chan_creds) ||
            (channel && updater_proc) ||
            (chan_creds && updater_proc)
-          raise ArgumentError, 'Only one of channel, chan_creds, and ' \
+          raise ArgumentError.new('Only one of channel, chan_creds, and ' \
               'updater_proc should be passed into ' \
-              'Google::Gax::Grpc#create_stub.'
+              'Google::Gax::Grpc#create_stub.')
         end
       end
 

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -254,7 +254,7 @@ module Google
         until done?
           sleep(delay)
           if Time.now >= deadline
-            raise RetryError, 'Retry total timeout exceeded with exception'
+            raise RetryError.new('Retry total timeout exceeded with exception')
           end
           delay = [delay * delay_multiplier, max_delay].min
           reload!

--- a/lib/google/gax/path_template.rb
+++ b/lib/google/gax/path_template.rb
@@ -175,7 +175,7 @@ module Google
             literal_sym = segment.literal.to_sym
             unless bindings.key?(literal_sym)
               msg = "Value for key #{segment.literal} is not provided"
-              raise(ArgumentError, msg)
+              raise ArgumentError.new(msg)
             end
             out.concat(PathTemplate.new(bindings[literal_sym]).segments)
             binding = true

--- a/lib/google/gax/util.rb
+++ b/lib/google/gax/util.rb
@@ -54,8 +54,9 @@ module Google
 
       # Sanity check: input must be a Hash
       unless hash.is_a? Hash
-        raise ArgumentError,
-              "Value #{hash} must be a Hash or a #{message_class.name}"
+        raise ArgumentError.new(
+          "Value #{hash} must be a Hash or a #{message_class.name}"
+        )
       end
       hash = coerce_submessages(hash, message_class)
       message_class.new(hash)
@@ -118,7 +119,7 @@ module Google
     # @return [Array<Object>] The coerced version of the given values.
     def coerce_array(array, field_descriptor)
       unless array.is_a? Array
-        raise ArgumentError, 'Value ' + array.to_s + ' must be an array'
+        raise ArgumentError.new('Value ' + array.to_s + ' must be an array')
       end
       array.map do |val|
         coerce(val, field_descriptor)

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -39,8 +39,8 @@ class CustomException < StandardError
   end
 end
 
-FAKE_STATUS_CODE_1 = :FAKE_STATUS_CODE_1
-FAKE_STATUS_CODE_2 = :FAKE_STATUS_CODE_2
+FAKE_STATUS_CODE_1 = 1
+FAKE_STATUS_CODE_2 = 2
 
 # Google::Gax::CallSettings is private, only accessible in the module context.
 # For testing purpose, this makes a toplevel ::CallSettings point to the same

--- a/spec/google/gax/bundling_spec.rb
+++ b/spec/google/gax/bundling_spec.rb
@@ -158,7 +158,7 @@ describe Google::Gax do
   # A dummy api call that raises an exception
   def raise_exc
     proc do |_|
-      raise Google::Gax::GaxError, 'Raised in a test'
+      raise Google::Gax::GaxError.new('Raised in a test')
     end
   end
 

--- a/spec/google/gax/error_spec.rb
+++ b/spec/google/gax/error_spec.rb
@@ -108,6 +108,102 @@ describe Google::Gax::GaxError do
     end
   end
 
+  describe '#from_error' do
+    it 'identifies CanceledError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(1, 'cancelled')
+      expect(mapped_error).to eq Google::Gax::CanceledError
+    end
+
+    it 'identifies UnknownError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(2, 'unknown')
+      expect(mapped_error).to eq Google::Gax::UnknownError
+    end
+
+    it 'identifies InvalidArgumentError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(3, 'invalid')
+      expect(mapped_error).to eq Google::Gax::InvalidArgumentError
+    end
+
+    it 'identifies DeadlineExceededError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(4, 'exceeded')
+      expect(mapped_error).to eq Google::Gax::DeadlineExceededError
+    end
+
+    it 'identifies NotFoundError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(5, 'not found')
+      expect(mapped_error).to eq Google::Gax::NotFoundError
+    end
+
+    it 'identifies AlreadyExistsError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(6, 'exists')
+      expect(mapped_error).to eq Google::Gax::AlreadyExistsError
+    end
+
+    it 'identifies PermissionDeniedError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(7, 'denied')
+      expect(mapped_error).to eq Google::Gax::PermissionDeniedError
+    end
+
+    it 'identifies ResourceExhaustedError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(8, 'exhausted')
+      expect(mapped_error).to eq Google::Gax::ResourceExhaustedError
+    end
+
+    it 'identifies FailedPreconditionError' do
+      mapped_error =
+        Google::Gax.from_error GRPC::BadStatus.new(9, 'precondition')
+      expect(mapped_error).to eq Google::Gax::FailedPreconditionError
+    end
+
+    it 'identifies AbortedError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(10, 'aborted')
+      expect(mapped_error).to eq Google::Gax::AbortedError
+    end
+
+    it 'identifies OutOfRangeError' do
+      mapped_error =
+        Google::Gax.from_error GRPC::BadStatus.new(11, 'out of range')
+      expect(mapped_error).to eq Google::Gax::OutOfRangeError
+    end
+
+    it 'identifies UnimplementedError' do
+      mapped_error =
+        Google::Gax.from_error GRPC::BadStatus.new(12, 'unimplemented')
+      expect(mapped_error).to eq Google::Gax::UnimplementedError
+    end
+
+    it 'identifies InternalError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(13, 'internal')
+      expect(mapped_error).to eq Google::Gax::InternalError
+    end
+
+    it 'identifies UnavailableError' do
+      mapped_error =
+        Google::Gax.from_error GRPC::BadStatus.new(14, 'unavailable')
+      expect(mapped_error).to eq Google::Gax::UnavailableError
+    end
+
+    it 'identifies DataLossError' do
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(15, 'data loss')
+      expect(mapped_error).to eq Google::Gax::DataLossError
+    end
+
+    it 'identifies UnauthenticatedError' do
+      mapped_error =
+        Google::Gax.from_error GRPC::BadStatus.new(16, 'unauthenticated')
+      expect(mapped_error).to eq Google::Gax::UnauthenticatedError
+    end
+
+    it 'identifies unknown error' do
+      # We don't know what to map this error case to
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(0, 'unknown')
+      expect(mapped_error).to eq Google::Gax::GaxError
+
+      mapped_error = Google::Gax.from_error GRPC::BadStatus.new(17, 'unknown')
+      expect(mapped_error).to eq Google::Gax::GaxError
+    end
+  end
+
   def wrap_with_gax_error(err)
     raise err
   rescue => e

--- a/spec/google/gax/error_spec.rb
+++ b/spec/google/gax/error_spec.rb
@@ -67,7 +67,7 @@ describe Google::Gax::GaxError do
     it 'presents GRPC::BadStatus values' do
       error = wrapped_badstatus(3, 'invalid')
 
-      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error).to be_a_kind_of(Google::Gax::GaxError)
       expect(error.message).to eq('GaxError 3:invalid, caused by 3:invalid')
       expect(error.code).to eq(3)
       expect(error.details).to eq('invalid')
@@ -93,7 +93,7 @@ describe Google::Gax::GaxError do
                    'grpc-status-details-bin' => encoded_status_detail }
       error = wrapped_badstatus(1, 'cancelled', metadata)
 
-      expect(error).to be_an_instance_of(Google::Gax::GaxError)
+      expect(error).to be_a_kind_of(Google::Gax::GaxError)
       expect(error.message).to eq('GaxError 1:cancelled, caused by 1:cancelled')
       expect(error.code).to eq(1)
       expect(error.details).to eq('cancelled')
@@ -111,7 +111,8 @@ describe Google::Gax::GaxError do
   def wrap_with_gax_error(err)
     raise err
   rescue => e
-    raise Google::Gax::GaxError, e.message
+    klass = Google::Gax.from_error(e)
+    raise klass.new(e.message)
   end
 
   def wrapped_error(msg)


### PR DESCRIPTION
This change allows GAX to raise more specific subclasses of GaxError
depending on the actual status of the call when the error is raised.

Fixes #100.