### PR TITLE
Update metadata handling and add block to expose grpc ops internally

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/LineLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 35
+  Max: 38
 
 # Offense count: 1
 Metrics/PerceivedComplexity:
@@ -36,7 +36,7 @@ Metrics/PerceivedComplexity:
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
-  Max: 26
+  Max: 28
 
 # Offense count: 3
 Style/Documentation:

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -136,15 +136,15 @@ module Google
       # @param request [Object]
       #   The initial request object.
       # @param settings [CallSettings]
-      #   The call settings to enumerate pages.
+      #   The call settings to enumerate pages
       # @return [PagedEnumerable]
       #   returning self for further uses.
-      def start(api_call, request, settings)
+      def start(api_call, request, settings, block)
         @func = api_call
         @request = request
         page_token = settings.page_token
         @request[@request_page_token_field] = page_token if page_token
-        @page = @page.dup_with(@func.call(@request))
+        @page = @page.dup_with(@func.call(@request, block))
         self
       end
 
@@ -222,8 +222,8 @@ module Google
     # @raise [StandardError] if +settings+ has incompatible values,
     #   e.g, if bundling and page_streaming are both configured
     def create_api_call(func, settings, params_extractor: nil)
-      api_caller = proc do |api_call, request|
-        api_call.call(request)
+      api_caller = proc do |api_call, request, settings, block|
+        api_call.call(request, block)
       end
 
       if settings.page_descriptor
@@ -239,7 +239,7 @@ module Google
         api_caller = bundleable(settings.bundle_descriptor)
       end
 
-      proc do |request, options = nil|
+      proc do |request, options = nil, &block|
         this_settings = settings.merge(options)
         if params_extractor
           params = params_extractor.call(request)
@@ -247,13 +247,13 @@ module Google
         end
         api_call = if settings.retry_codes?
                      retryable(func, this_settings.retry_options,
-                               this_settings.kwargs)
+                               this_settings.metadata)
                    else
                      add_timeout_arg(func, this_settings.timeout,
-                                     this_settings.kwargs)
+                                     this_settings.metadata)
                    end
         begin
-          api_caller.call(api_call, request, this_settings)
+          api_caller.call(api_call, request, this_settings, block)
         rescue *settings.errors => e
           error_class = Google::Gax.from_error e
           raise error_class.new('RPC failed')
@@ -277,12 +277,13 @@ module Google
     # @return [Proc] A proc takes the API call's request and returns
     #   an Event object.
     def bundleable(desc)
-      proc do |api_call, request, settings|
-        return api_call(request) unless settings.bundler
+      proc do |api_call, request, settings, block|
+        return api_call(request, block) unless settings.bundler
         the_id = Google::Gax.compute_bundle_id(
           request,
           desc.request_discriminator_fields
         )
+        # TODO: how to handle the block arg in next line?
         settings.bundler.schedule(api_call, the_id, desc, request)
       end
     end
@@ -316,7 +317,7 @@ module Google
     def with_routing_header(settings, params)
       routing_header = params.map { |k, v| "#{k}=#{v}" }.join('&')
       options = CallOptions.new(
-        kwargs: { 'x-goog-request-params' => routing_header }
+          metadata: { 'x-goog-request-params' => routing_header }
       )
       settings.merge(options)
     end
@@ -328,8 +329,9 @@ module Google
     # @param retry_options [RetryOptions] Configures the exceptions
     #   upon which the proc should retry, and the parameters to the
     #   exponential backoff retry algorithm.
+    # @param metadata [Hash] request metadata headers
     # @return [Proc] A proc that will retry on exception.
-    def retryable(a_func, retry_options, kwargs)
+    def retryable(a_func, retry_options, metadata)
       delay_mult = retry_options.backoff_settings.retry_delay_multiplier
       max_delay = (retry_options.backoff_settings.max_retry_delay_millis /
                    MILLIS_PER_SECOND)
@@ -339,13 +341,19 @@ module Google
       total_timeout = (retry_options.backoff_settings.total_timeout_millis /
                        MILLIS_PER_SECOND)
 
-      proc do |request|
+      proc do |request, block|
         delay = retry_options.backoff_settings.initial_retry_delay_millis
         timeout = (retry_options.backoff_settings.initial_rpc_timeout_millis /
                    MILLIS_PER_SECOND)
         deadline = Time.now + total_timeout
         begin
-          a_func.call(request, deadline: Time.now + timeout, metadata: kwargs)
+          op = a_func.call(request,
+                           deadline: Time.now + timeout,
+                           metadata: metadata,
+                           return_op: true)
+          res = op.execute
+          block.call op if block
+          res
         rescue => exception
           unless exception.respond_to?(:code) &&
                  retry_options.retry_codes.include?(exception.code)
@@ -372,10 +380,17 @@ module Google
     # @param a_func [Proc] a proc to be updated
     # @param timeout [Numeric] to be added to the original proc as it
     #   final positional arg.
+    # @param metadata [Hash] request metadata headers
     # @return [Proc] the original proc updated to the timeout arg
-    def add_timeout_arg(a_func, timeout, kwargs)
-      proc do |request|
-        a_func.call(request, deadline: Time.now + timeout, metadata: kwargs)
+    def add_timeout_arg(a_func, timeout, metadata)
+      proc do |request, block|
+        op = a_func.call(request,
+                         deadline: Time.now + timeout,
+                         metadata: metadata,
+                         return_top: true)
+        res = op.execute
+        block.call op if block
+        res
       end
     end
 

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -222,7 +222,7 @@ module Google
     # @raise [StandardError] if +settings+ has incompatible values,
     #   e.g, if bundling and page_streaming are both configured
     def create_api_call(func, settings, params_extractor: nil)
-      api_caller = proc do |api_call, request, settings, block|
+      api_caller = proc do |api_call, request, _settings, block|
         api_call.call(request, block)
       end
 
@@ -317,7 +317,7 @@ module Google
     def with_routing_header(settings, params)
       routing_header = params.map { |k, v| "#{k}=#{v}" }.join('&')
       options = CallOptions.new(
-          metadata: { 'x-goog-request-params' => routing_header }
+        metadata: { 'x-goog-request-params' => routing_header }
       )
       settings.merge(options)
     end

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -387,7 +387,7 @@ module Google
         op = a_func.call(request,
                          deadline: Time.now + timeout,
                          metadata: metadata,
-                         return_top: true)
+                         return_op: true)
         res = op.execute
         block.call op if block
         res

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -279,11 +279,11 @@ module Google
     def bundleable(desc)
       proc do |api_call, request, settings, block|
         return api_call(request, block) unless settings.bundler
+        raise 'Bundling calls cannot accept blocks' if block
         the_id = Google::Gax.compute_bundle_id(
           request,
           desc.request_discriminator_fields
         )
-        # TODO: how to handle the block arg in next line?
         settings.bundler.schedule(api_call, the_id, desc, request)
       end
     end

--- a/lib/google/gax/api_callable.rb
+++ b/lib/google/gax/api_callable.rb
@@ -352,7 +352,7 @@ module Google
                            metadata: metadata,
                            return_op: true)
           res = op.execute
-          block.call op if block
+          block.call res, op if block
           res
         rescue => exception
           unless exception.respond_to?(:code) &&

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -123,7 +123,7 @@ module Google
                        options.page_token
                      end
 
-        metadata = metadata.dup || {}
+        metadata = (metadata.dup if metadata) || {}
         metadata.update(options.metadata) if options.metadata != :OPTION_INHERIT
 
         CallSettings.new(timeout: timeout,

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -481,7 +481,8 @@ module Google
     #   service is not found in the config.
     def construct_settings(service_name, client_config, config_overrides,
                            retry_names, timeout, bundle_descriptors: {},
-                           page_descriptors: {}, metadata: {}, kwargs: {}, errors: [])
+                           page_descriptors: {}, metadata: {}, kwargs: {},
+                           errors: [])
       defaults = {}
 
       metadata.merge!(kwargs) if kwargs.is_a?(Hash) && metadata.is_a?(Hash)

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -159,7 +159,7 @@ module Google
       # @param page_token [Object, :OPTION_INHERIT]
       #   If set and the call is configured for page streaming, page streaming
       #   is starting with this page_token.
-      # @param metadata [Hash] the request header params.
+      # @param metadata [Hash, :OPTION_INHERIT] the request header params.
       # @param kwargs [Hash, :OPTION_INHERIT]
       #   Deprecated, if set this will be merged with the metadata field.
       def initialize(timeout: :OPTION_INHERIT,

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -473,14 +473,18 @@ module Google
     #   methods that are page streaming-enabled.
     # @param metadata [Hash]
     #   Header params to be passed to the API call.
+    # @param kwargs [Hash]
+    #   Deprecated, same as metadata and if present will be merged with metadata
     # @param errors [Array<Exception>]
     #   Configures the exceptions to wrap with GaxError.
     # @return [CallSettings, nil] A CallSettings, or nil if the
     #   service is not found in the config.
     def construct_settings(service_name, client_config, config_overrides,
                            retry_names, timeout, bundle_descriptors: {},
-                           page_descriptors: {}, metadata: {}, errors: [])
+                           page_descriptors: {}, metadata: {}, kwargs: {}, errors: [])
       defaults = {}
+
+      metadata.merge!(kwargs) if kwargs.is_a?(Hash) && metadata.is_a?(Hash)
 
       service_config = client_config.fetch('interfaces', {})[service_name]
       return nil unless service_config

--- a/spec/google/gax/api_callable_spec.rb
+++ b/spec/google/gax/api_callable_spec.rb
@@ -57,7 +57,7 @@ describe Google::Gax do
       settings = CallSettings.new
       deadline_arg = nil
 
-      op = double("op")
+      op = double('op')
       allow(op).to receive(:execute) { 42 }
 
       func = proc do |deadline: nil, **_kwargs|
@@ -81,11 +81,10 @@ describe Google::Gax do
       adder = 0
       settings = CallSettings.new
 
-      op = double("op", :request => 3)
+      op = double('op', request: 3)
       allow(op).to receive(:execute) { 2 + op.request + adder }
 
-      func = proc do |request, deadline: nil, **_kwargs|
-        deadline_arg = deadline
+      func = proc do |request, _deadline: nil, **_kwargs|
         expect(request).to eq(3)
         op
       end
@@ -119,7 +118,7 @@ describe Google::Gax do
 
     it 'iterates over elements' do
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -133,7 +132,7 @@ describe Google::Gax do
 
     it 'offers interface for pages' do
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -152,7 +151,7 @@ describe Google::Gax do
 
     it 'starts from the specified page_token' do
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -232,7 +231,7 @@ describe Google::Gax do
         request['elements'].count
       end
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -256,7 +255,7 @@ describe Google::Gax do
         42
       end
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -295,7 +294,7 @@ describe Google::Gax do
         1729
       end
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end
@@ -378,7 +377,7 @@ describe Google::Gax do
     it 'does not retry even when no responses' do
       func = proc { nil }
       func2 = proc do |request, **kwargs|
-        op = double("op")
+        op = double('op')
         allow(op).to receive(:execute) { func.call(request, **kwargs) }
         op
       end

--- a/spec/google/gax/settings_spec.rb
+++ b/spec/google/gax/settings_spec.rb
@@ -91,7 +91,7 @@ describe Google::Gax do
       SERVICE_NAME, A_CONFIG, {}, RETRY_DICT, 30,
       bundle_descriptors: BUNDLE_DESCRIPTORS,
       page_descriptors: PAGE_DESCRIPTORS,
-      kwargs: { 'key' => 'value' },
+      metadata: { 'key' => 'value' },
       errors: [StandardError]
     )
     settings = defaults['bundling_method']
@@ -104,7 +104,7 @@ describe Google::Gax do
     expect(settings.retry_options.backoff_settings).to be_a(
       Google::Gax::BackoffSettings
     )
-    expect(settings.kwargs).to match('key' => 'value')
+    expect(settings.metadata).to match('key' => 'value')
     expect(settings.errors).to match_array([StandardError])
 
     settings = defaults['some_https_page_streaming_method']
@@ -117,7 +117,7 @@ describe Google::Gax do
     expect(settings.retry_options.backoff_settings).to be_a(
       Google::Gax::BackoffSettings
     )
-    expect(settings.kwargs).to match('key' => 'value')
+    expect(settings.metadata).to match('key' => 'value')
     expect(settings.errors).to match_array([StandardError])
   end
 


### PR DESCRIPTION
This is a WIP for a potential new toolkit feature. The main goal is to invoke all internal grpc calls using the return_op=true flag so that any additional grpc information is available and can be trapped in gax, via an optional block. Those blocks will then be used by the generated gapic methods to trap and expose things like response metadata to the caller.

Related toolkit change: https://github.com/googleapis/toolkit/pull/1865

Note: Do not merge until the feature is finalized!