### PR TITLE
Release google-gax v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.1.0 / 2018-3-20
 
 * Add support for passing blocks to unary RPC calls
+* Deprecated kwargs in call settings and replaced with metadata
 
 ### 1.0.1 / 2017-12-21
 

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end


### PR DESCRIPTION
It seems this requires a review, unlike in google-cloud-ruby