### PR TITLE
Lookup Operation types to unpack

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Prefer compact style, as Ruby runtime overwrites the GAX error message
 # when exploded exception style is used.
+Metrics/ClassLength:
+  Max: 110
 Style/RaiseArgs:
   EnforcedStyle: compact

--- a/lib/google/gax/bundling.rb
+++ b/lib/google/gax/bundling.rb
@@ -77,8 +77,6 @@ module Google
       result
     end
 
-    # rubocop:disable Metrics/ClassLength
-
     # Coordinates the execution of a single bundle.
     #
     # @!attribute [r] bundle_id

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -33,7 +33,6 @@ require 'time'
 require 'google/gax/constants'
 require 'google/gax/settings'
 require 'google/protobuf/well_known_types'
-require 'uri'
 
 module Google
   module Gax
@@ -158,18 +157,14 @@ module Google
       def metadata
         return if @grpc_op.metadata.nil?
 
-        @metadata_type ||= begin
-          lookup_uri = URI.parse(@grpc_op.metadata.type_url)
-          lookup_type = lookup_uri.path.split('/'.freeze).last
-          lookup_desc = Google::Protobuf::DescriptorPool.generated_pool.lookup(
-            lookup_type
-          )
-          lookup_desc.msgclass if lookup_desc
-        end
+        return @grpc_op.metadata.unpack(@metadata_type) if @metadata_type
 
-        return @grpc_op.metadata if @metadata_type.nil?
+        descriptor = Google::Protobuf::DescriptorPool.generated_pool.lookup(
+          @grpc_op.metadata.type_name
+        )
+        return @grpc_op.metadata.unpack(descriptor.msgclass) if descriptor
 
-        @grpc_op.metadata.unpack(@metadata_type)
+        @grpc_op.metadata
       end
 
       # Checks if the operation is done. This does not send a new api call,
@@ -195,18 +190,14 @@ module Google
       def response
         return unless response?
 
-        @result_type ||= begin
-          lookup_uri = URI.parse(@grpc_op.response.type_url)
-          lookup_type = lookup_uri.path.split('/'.freeze).last
-          lookup_desc = Google::Protobuf::DescriptorPool.generated_pool.lookup(
-            lookup_type
-          )
-          lookup_desc.msgclass if lookup_desc
-        end
+        return @grpc_op.response.unpack(@result_type) if @result_type
 
-        return @grpc_op.response if @result_type.nil?
+        descriptor = Google::Protobuf::DescriptorPool.generated_pool.lookup(
+          @grpc_op.response.type_name
+        )
+        return @grpc_op.response.unpack(descriptor.msgclass) if descriptor
 
-        @grpc_op.response.unpack(@result_type)
+        @grpc_op.response
       end
 
       # Checks if the operation is done and the result is an error.


### PR DESCRIPTION
This PR changes `Google::Gax::Operation` to lookup the result and metadata types used to unpack the values from the `Google::LongRunning::Operation` object. This only happens when the `result_type` or `metadata_type` values are passed in as `nil` (which currently results in an error).

This change will enable the GAPIC client objects to retrieving operations through a `get_operation` and a `list_operation` method without having to know the specific result and metadata types to set. There are several APIs that have operation collections which contain resources with varied result and metadata types. Each `Google::LongRunning::Operation` object would have to be inspected and the result and metadata types discovered before passing to `Google::Gax::Operation.new`. This PR moves the result and metadata types discovery to `Google::Gax::Operation`.