### PR TITLE
Use descriptor pool for deserialization

### DIFF
--- a/lib/google/gax/grpc.rb
+++ b/lib/google/gax/grpc.rb
@@ -65,12 +65,13 @@ module Google
             error.to_status
           ).details
         details.map do |any|
-          # If the type of the proto wrapped by the Any instance is not
-          # available, do not deserialize.
-          candidate_class_name = class_case(any.type_name.split('.')).join('::')
+          # deserialize the proto wrapped by the Any in the error details
           begin
-            any.unpack(Object.const_get(candidate_class_name))
-          rescue NameError
+            type = Google::Protobuf::DescriptorPool.generated_pool.lookup(
+              any.type_name
+            )
+            any.unpack(type.msgclass)
+          rescue
             any
           end
         end

--- a/spec/google/gax/grpc_spec.rb
+++ b/spec/google/gax/grpc_spec.rb
@@ -161,6 +161,7 @@ describe Google::Gax::Grpc do
       end.to raise_error(ArgumentError)
     end
   end
+
   describe '#deserialize_error_status_details' do
     it 'deserializes a known error type' do
       expected_error = Google::Rpc::DebugInfo.new(detail: 'shoes are untied')
@@ -177,6 +178,7 @@ describe Google::Gax::Grpc do
       expect(Google::Gax::Grpc.deserialize_error_status_details(error))
         .to eq [expected_error]
     end
+
     it 'does not deserialize an unknown error type' do
       expected_error = Random.new.bytes(8)
 


### PR DESCRIPTION
This library attempts to automatically `unpack` the error messages details field (an `Any` proto) when an RPC fails. This was originally implemented by reconstructing the expected Ruby class name from the `type_name` property of the `Any` object. 

This change replaces that by `unpack` ing the object using the generated descriptor pool instead. A `ruby_namespace` option was added to protobuf around version 3.6, which makes the original implementation unreliable when used.