### PR TITLE
Update Operations documentation

### DIFF
--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -105,9 +105,9 @@ module Google
       #   The inital longrunning operation.
       # @param client [Google::Longrunning::OperationsClient]
       #   The client that handles the grpc operations.
-      # @param result_type [Class] The class type to be unpacked from the
+      # @param result_type [Class, nil] The class type to be unpacked from the
       #   result. When a `nil` value is given the class type will be looked up.
-      # @param metadata_type [Class] The class type to be unpacked from the
+      # @param metadata_type [Class, nil] The class type to be unpacked from the
       #   metadata. When a `nil` value is given the class type will be looked
       #   up.
       # @param call_options [Google::Gax::CallOptions]

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -106,9 +106,10 @@ module Google
       # @param client [Google::Longrunning::OperationsClient]
       #   The client that handles the grpc operations.
       # @param result_type [Class] The class type to be unpacked from the
-      #   result.
+      #   result. When a `nil` value is given the class type will be looked up.
       # @param metadata_type [Class] The class type to be unpacked from the
-      #   metadata.
+      #   metadata. When a `nil` value is given the class type will be looked
+      #   up.
       # @param call_options [Google::Gax::CallOptions]
       #   The call options that are used when reloading the operation.
       def initialize(grpc_op, client, result_type, metadata_type,

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -111,7 +111,7 @@ module Google
       #   metadata. When a `nil` value is given the class type will be looked
       #   up.
       # @param call_options [Google::Gax::CallOptions]
-      #   The call options that are used when reloading the operation.
+      #   The call options that are used when reloading the operation. Optional.
       def initialize(grpc_op, client, result_type, metadata_type,
                      call_options: nil)
         @grpc_op = grpc_op


### PR DESCRIPTION
* Document lookup behavior of `result_type` and `metadata_type` type classes when passed in as `nil`.
* Document `call_options` as an optional argument.

[closes #139]