### PR TITLE
Make Operation class type arguments optional

### DIFF
--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -105,14 +105,13 @@ module Google
       #   The inital longrunning operation.
       # @param client [Google::Longrunning::OperationsClient]
       #   The client that handles the grpc operations.
-      # @param result_type [Class, nil] The class type to be unpacked from the
-      #   result. When a `nil` value is given the class type will be looked up.
-      # @param metadata_type [Class, nil] The class type to be unpacked from the
-      #   metadata. When a `nil` value is given the class type will be looked
-      #   up.
+      # @param result_type [Class] The class type to be unpacked from the
+      #   result. If not provided the class type will be looked up. Optional.
+      # @param metadata_type [Class] The class type to be unpacked from the
+      #   metadata. If not provided the class type will be looked up. Optional.
       # @param call_options [Google::Gax::CallOptions]
       #   The call options that are used when reloading the operation. Optional.
-      def initialize(grpc_op, client, result_type, metadata_type,
+      def initialize(grpc_op, client, result_type = nil, metadata_type = nil,
                      call_options: nil)
         @grpc_op = grpc_op
         @client = client

--- a/spec/google/gax/operation_spec.rb
+++ b/spec/google/gax/operation_spec.rb
@@ -142,6 +142,15 @@ describe Google::Gax::Operation do
       expect(op.metadata).to eq(TIMESTAMP)
     end
 
+    it 'should lookup and unpack the metadata when metadata_type is not ' \
+       'provided' do
+      op = GaxOp.new( # create Operation without result_type or metadata_type
+        GrpcOp.new(done: true, metadata: TIMESTAMP_ANY),
+        DONE_ON_GET_CLIENT
+      )
+      expect(op.metadata).to eq(TIMESTAMP)
+    end
+
     it 'should return original metadata when metadata_type is not found when ' \
        'looked up.' do
       op = create_op(GrpcOp.new(done: true, metadata: UNKNOWN_ANY),
@@ -235,6 +244,15 @@ describe Google::Gax::Operation do
     it 'should unpack the result when result_type is looked up.' do
       op = create_op(GrpcOp.new(done: true, response: TIMESTAMP_ANY),
                      result_type: nil)
+      expect(op.response).to eq(TIMESTAMP)
+    end
+
+    it 'should lookup and unpack the result when result_type is not ' \
+       'provided.' do
+      op = GaxOp.new( # create Operation without result_type or metadata_type
+        GrpcOp.new(done: true, response: TIMESTAMP_ANY),
+        DONE_ON_GET_CLIENT
+      )
       expect(op.response).to eq(TIMESTAMP)
     end
 


### PR DESCRIPTION
This PR changes the `Google::Gax::Operation` `result_type` and `metadata_type` arguments to be optional. This is a backwards compatible change.