### PR TITLE
Loosen googleauth dependency

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'googleauth', '>= 0.6.2', '< 0.8.0'
+  s.add_dependency 'googleauth', '>= 0.6.2', '< 0.10.0'
   s.add_dependency 'grpc', '>= 1.7.2', '< 2.0'
   s.add_dependency 'googleapis-common-protos', '>= 1.3.5', '< 2.0'
   s.add_dependency 'google-protobuf', '~> 3.2'


### PR DESCRIPTION
Loosen the googleauth dependency to allow future changes. The team supporting googleauth has committed to not change backwards compatibility before 0.10.0.