### PR TITLE
Fix CI build and add Ruby 2.6 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,10 @@
 source 'https://rubygems.org/'
 
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3")
+  # WORKAROUND: google-protobuf 3.7.0 and newer dropped ruby 2.2 and older,
+  # but the gem isn't specifying a minimum ruby for the pre-compiled versions.
+  # Downgrade the gem when running on 2.2.
+  gem 'google-protobuf', '~> 3.6.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org/'
 
 gemspec
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3")
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
   # WORKAROUND: google-protobuf 3.7.0 and newer dropped ruby 2.2 and older,
   # but the gem isn't specifying a minimum ruby for the pre-compiled versions.
   # Downgrade the gem when running on 2.2.

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ source 'https://rubygems.org/'
 gemspec
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+  # WORKAROUND: googleauth 0.8.0 and newer are using ruby 2.3 syntax
+  # but the gem isn't specifying a minimum ruby.
+  # Downgrade the gem when running on 2.2.
+  gem 'googleauth', '~> 0.7.0'
   # WORKAROUND: google-protobuf 3.7.0 and newer dropped ruby 2.2 and older,
   # but the gem isn't specifying a minimum ruby for the pre-compiled versions.
   # Downgrade the gem when running on 2.2.


### PR DESCRIPTION
* Add workaround for using google-protobuf on ruby < 2.3.
* Add Ruby 2.6 to CI