### PR TITLE
Update version to 2.0.alpha.0.development

### DIFF
--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = "1.5.0".freeze
+    VERSION = "2.0.alpha.0.development".freeze
   end
 end


### PR DESCRIPTION
We want to indicate that the master branch is not compatible with the current release, so use 2.0. But, we don't want it released, so append alpha and development to the version number to make that as obvious as possible.