### PR TITLE
Operation Updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ end
 require "rubocop/rake_task"
 RuboCop::RakeTask.new :rubocop
 
-task default: %i[test rubocop]
+task default: [:test, :rubocop]

--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "grpc", ">= 1.7.2", "< 2.0"
 
   gem.add_development_dependency "codecov", "~> 0.1"
-  gem.add_development_dependency "google-style", "~> 0.2"
+  gem.add_development_dependency "google-style", "~> 0.3"
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -214,7 +214,7 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        @client.cancel_operation @grpc_op.name, options: options
+        @client.cancel_operation name: @grpc_op.name, options: options
       end
 
       ##
@@ -227,7 +227,7 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        @client.delete_operation @grpc_op.name, options: options
+        @client.delete_operation name: @grpc_op.name, options: options
       end
 
       ##
@@ -242,7 +242,8 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        @grpc_op = @client.get_operation @grpc_op.name, options: options
+        gax_op = @client.get_operation name: @grpc_op.name, options: options
+        @grpc_op = gax_op.grpc_op
 
         if done?
           @on_done_callbacks.each { |proc| proc.call self }

--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -100,7 +100,7 @@ module Google
       # @param metadata_type [Class] The class type to be unpacked from the metadata. If not provided the class type
       #   will be looked up. Optional.
       #
-      def initialize grpc_op, client, result_type = nil, metadata_type = nil
+      def initialize grpc_op, client, result_type: nil, metadata_type: nil
         @grpc_op = grpc_op
         @client = client
         @result_type = result_type

--- a/lib/google/gax/paged_enumerable.rb
+++ b/lib/google/gax/paged_enumerable.rb
@@ -169,7 +169,7 @@ module Google
         raise ArgumentError, "#{@request.class} must have a page_token field (String)" if page_token.nil?
 
         page_size = @request.class.descriptor.find do |f|
-          f.name == "page_size" && %i[int32 int64].include?(f.type)
+          f.name == "page_size" && [:int32, :int64].include?(f.type)
         end
         return unless page_size.nil?
         raise ArgumentError, "#{@request.class} must have a page_size field (Integer)"

--- a/test/google/gax/operation_test.rb
+++ b/test/google/gax/operation_test.rb
@@ -45,16 +45,17 @@ class MockLroClient
     @delete_method = delete_method
   end
 
-  def get_operation grpc_method, options: nil
-    @get_method.call grpc_method, options
+  def get_operation name:, options: nil
+    grpc_op = @get_method.call name: name, options: options
+    Google::Gax::Operation.new grpc_op, self
   end
 
-  def cancel_operation name, options: nil
-    @cancel_method.call name, options: options
+  def cancel_operation name:, options: nil
+    @cancel_method.call name: name, options: options
   end
 
-  def delete_operation name, options: nil
-    @delete_method.call name, options: options
+  def delete_operation name:, options: nil
+    @delete_method.call name: name, options: options
   end
 end
 
@@ -263,8 +264,9 @@ describe Google::Gax::Operation do
     it "should call the clients cancel_operation" do
       op_name = "test_name"
       called = false
-      cancel_method = proc do |name|
+      cancel_method = proc do |name:, options:|
         _(name).must_equal op_name
+        _(options).must_be_kind_of Google::Gax::ApiCall::Options
         called = true
       end
       mock_client = MockLroClient.new cancel_method: cancel_method
@@ -277,7 +279,7 @@ describe Google::Gax::Operation do
     it "should call the clients delete_operation" do
       op_name = "test_name"
       called = false
-      delete_method = proc do |name, options: options|
+      delete_method = proc do |name:, options:|
         _(name).must_equal op_name
         _(options).must_be_kind_of Google::Gax::ApiCall::Options
         called = true
@@ -291,12 +293,14 @@ describe Google::Gax::Operation do
   describe "method `reload!`" do
     it "should call the get_operation of the client" do
       called = false
-      get_method = proc do
+      get_method = proc do |name:, options:|
         called = true
+        _(name).must_equal "name"
+        _(options).must_be_kind_of Google::Gax::ApiCall::Options
         GrpcOp.new done: true, response: RESULT_ANY
       end
       mock_client = MockLroClient.new get_method: get_method
-      op = create_op GrpcOp.new(done: false), client: mock_client
+      op = create_op GrpcOp.new(done: false, name: "name"), client: mock_client
       _(called).must_equal false
       op.reload!
       _(called).must_equal true
@@ -305,7 +309,7 @@ describe Google::Gax::Operation do
     it "should use options attribute when reloading" do
       options = Google::Gax::ApiCall::Options.new
       called = false
-      get_method = proc do |name, options|
+      get_method = proc do |name:, options:|
         called = true
         _(name).must_equal "name"
         _(options).must_be_kind_of Google::Gax::ApiCall::Options

--- a/test/google/gax/operation_test.rb
+++ b/test/google/gax/operation_test.rb
@@ -88,8 +88,8 @@ def create_op operation, client: nil, result_type: Google::Rpc::Status,
   GaxOp.new(
     operation,
     client || DONE_ON_GET_CLIENT,
-    result_type,
-    metadata_type
+    result_type: result_type,
+    metadata_type: metadata_type
   )
 end
 


### PR DESCRIPTION
Use the new `Operations` class from gapic generator. Update the constructor to use named arguments for optional arguments (`result_type` and `metadata_type`).