### PR TITLE
Add Config DSL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,19 @@ Metrics/ClassLength:
     - "lib/google/gax/configuration.rb"
     - "lib/google/gax/configuration/schema.rb"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/gax/config.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/gax/config.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/gax/config.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/gax/config.rb"
+
 Style/Documentation:
   Exclude:
     - "lib/google/gax/api_call.rb"
@@ -26,3 +39,4 @@ Style/CaseEquality:
     - "lib/google/gax/configuration.rb"
     - "lib/google/gax/configuration/derived.rb"
     - "lib/google/gax/configuration/schema.rb"
+    - "lib/google/gax/config.rb"

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -83,9 +83,6 @@ module Google
           if instance_variable_defined? :@parent_config
             parent = instance_variable_get :@parent_config
             return parent.send name if parent&.respond_to? name
-
-            parent = instance_variable_get :@parent_config
-            return parent.send name if parent&.respond_to? name
           end
 
           default

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -38,67 +38,65 @@ module Google
       # @param [Hash] opts Validation options
       #
       def config_attr name, default, *valid_values, &validator
-         name = String(name).to_sym
-         raise "cannot create field named parent_config" if name == :parent_config
-         raise "method #{name} already exists" if method_defined? name
+        name = String(name).to_sym
+        raise "cannot create field named parent_config" if name == :parent_config
+        raise "method #{name} already exists" if method_defined? name
 
-         raise "validation must be provided" if validator.nil? && valid_values.empty?
-         validator ||= ->(value) { valid_values.any? { |v| v === value } }
+        raise "validation must be provided" if validator.nil? && valid_values.empty?
+        validator ||= ->(value) { valid_values.any? { |v| v === value } }
 
-         name_ivar = "@#{name}".to_sym
+        name_ivar = "@#{name}".to_sym
 
-         if default.nil?
-           # create getter
-           define_method name do
-             value = instance_variable_get name_ivar
-             if value.nil?
-               parent = instance_variable_get :@parent_config
-               if parent&.respond_to? name
-                 return parent.send name
-               end
-             end
-             value
-           end
-           # create setter
-           define_method "#{name}=" do |new_value|
-             parent = instance_variable_get :@parent_config
-             valid_value = validator.call new_value
-             # Allow nil if parent config has the same method.
-             valid_value = true if new_value.nil? && parent&.respond_to?(name)
-             raise ArgumentError unless valid_value
-             if new_value.nil?
-               remove_instance_variable name_ivar if instance_variable_defined? name_ivar
-             else
-               instance_variable_set name_ivar, new_value
-             end
-           end
-         else
-           # create getter with default value
-           define_method name do
-             value = instance_variable_get name_ivar
-             if value.nil?
-               parent = instance_variable_get :@parent_config
-               if parent&.respond_to? name
-                 return parent.send name
-               else
-                 return default
-               end
-             end
-             value
-           end
-           # create setter with default value
-           define_method "#{name}=" do |new_value|
-             valid_value = validator.call new_value
-             # Always allow nil because we have a default value
-             valid_value = true if new_value.nil?
-             raise ArgumentError unless valid_value
-             if new_value.nil?
-               remove_instance_variable name_ivar if instance_variable_defined? name_ivar
-             else
-               instance_variable_set name_ivar, new_value
-             end
-           end
-         end
+        if default.nil?
+          # create getter
+          define_method name do
+            value = instance_variable_get name_ivar
+            if value.nil?
+              parent = instance_variable_get :@parent_config
+              return parent.send name if parent&.respond_to? name
+            end
+            value
+          end
+          # create setter
+          define_method "#{name}=" do |new_value|
+            parent = instance_variable_get :@parent_config
+            valid_value = validator.call new_value
+            # Allow nil if parent config has the same method.
+            valid_value = true if new_value.nil? && parent&.respond_to?(name)
+            raise ArgumentError unless valid_value
+            if new_value.nil?
+              remove_instance_variable name_ivar if instance_variable_defined? name_ivar
+            else
+              instance_variable_set name_ivar, new_value
+            end
+          end
+        else
+          # create getter with default value
+          define_method name do
+            value = instance_variable_get name_ivar
+            if value.nil?
+              parent = instance_variable_get :@parent_config
+              if parent&.respond_to? name
+                return parent.send name
+              else
+                return default
+              end
+            end
+            value
+          end
+          # create setter with default value
+          define_method "#{name}=" do |new_value|
+            valid_value = validator.call new_value
+            # Always allow nil because we have a default value
+            valid_value = true if new_value.nil?
+            raise ArgumentError unless valid_value
+            if new_value.nil?
+              remove_instance_variable name_ivar if instance_variable_defined? name_ivar
+            else
+              instance_variable_set name_ivar, new_value
+            end
+          end
+        end
       end
     end
   end

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -76,11 +76,8 @@ module Google
             value = instance_variable_get name_ivar
             if value.nil?
               parent = instance_variable_get :@parent_config
-              if parent&.respond_to? name
-                return parent.send name
-              else
-                return default
-              end
+              return parent.send name if parent&.respond_to? name
+              return default
             end
             value
           end

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -29,6 +29,33 @@
 
 module Google
   module Gax
+    ##
+    # Config is a simple DSL for creating Configuration classes.
+    #
+    # @example
+    #   require "google/gax/config"
+    #
+    #   class SampleConfig
+    #     extend Google::Gax::Config
+    #
+    #     config_attr :name,   nil,         String, nil
+    #     config_attr :active, true,        true, false
+    #     config_attr :count,  nil,         Numeric, nil
+    #     config_attr :env,    :production, String, Symbol
+    #
+    #     def initialize parent_config = nil
+    #       @parent_config = parent_config unless parent_config.nil?
+    #       yield self if block_given?
+    #     end
+    #   end
+    #
+    #   config = SampleConfig.new
+    #
+    #   config.name             #=> nil
+    #   config.name = "thor"    #=> "thor"
+    #   config.name             #=> "thor"
+    #   config.name = :thor     # ArgumentError
+    #
     module Config
       ##
       # Add configuration attribute methods to the configuratin class.

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -66,10 +66,12 @@ module Google
       #
       def config_attr name, default, *valid_values, &validator
         name = String(name).to_sym
-        raise "cannot create field named parent_config" if name == :parent_config
-        raise "method #{name} already exists" if method_defined? name
+        name_setter = "#{name}=".to_sym
+        raise NameError, "invalid config name #{name}" if name !~ /^[a-zA-Z]\w*$/ || name == :parent_config
+        raise NameError, "method #{name} already exists" if method_defined? name
+        raise NameError, "method #{name_setter} already exists" if method_defined? name_setter
 
-        raise "validation must be provided" if validator.nil? && valid_values.empty?
+        raise ArgumentError, "validation must be provided" if validator.nil? && valid_values.empty?
         validator ||= ->(value) { valid_values.any? { |v| v === value } }
 
         name_ivar = "@#{name}".to_sym
@@ -90,7 +92,7 @@ module Google
         end
 
         # create setter
-        define_method "#{name}=" do |new_value|
+        define_method name_setter do |new_value|
           valid_value = validator.call new_value
           if new_value.nil?
             # Always allow nil when a default value is present

--- a/lib/google/gax/config.rb
+++ b/lib/google/gax/config.rb
@@ -1,0 +1,88 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module Google
+  module Gax
+    module Config
+      ##
+      # Add configuration attribute methods to the configuratin class.
+      #
+      # @param [String, Symbol] key The name of the option
+      # @param [Object, nil] initial Initial value (nil is allowed)
+      # @param [Hash] opts Validation options
+      #
+      def config_attr name, default, *valid_values, &validator
+         name = String(name).to_sym
+         raise "method #{name} already exists" if method_defined? name
+
+         raise "validation must be provided" if validator.nil? && valid_values.empty?
+         validator ||= ->(value) { valid_values.any? { |v| v === value } }
+
+         name_ivar = "@#{name}".to_sym
+
+         if default.nil?
+           # create getter
+           define_method name do
+             value = instance_variable_get name_ivar
+             value
+           end
+           # create setter
+           define_method "#{name}=" do |new_value|
+             valid_value = validator.call new_value
+             raise ArgumentError unless valid_value
+             if new_value.nil?
+               remove_instance_variable name_ivar if instance_variable_defined? name_ivar
+             else
+               instance_variable_set name_ivar, new_value
+             end
+           end
+         else
+           # create getter with default value
+           define_method name do
+             value = instance_variable_get name_ivar
+             return default if value.nil?
+             value
+           end
+           # create setter with default value
+           define_method "#{name}=" do |new_value|
+             valid_value = validator.call new_value
+             # Always allow nil because we have a default value
+             valid_value = true if new_value.nil?
+             raise ArgumentError unless valid_value
+             if new_value.nil?
+               remove_instance_variable name_ivar if instance_variable_defined? name_ivar
+             else
+               instance_variable_set name_ivar, new_value
+             end
+           end
+         end
+      end
+    end
+  end
+end

--- a/lib/google/gax/config/method.rb
+++ b/lib/google/gax/config/method.rb
@@ -1,0 +1,82 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module Google
+  module Gax
+    module Config
+      ##
+      # Config::Method is a configuration class that represents the configuration for an API RPC call.
+      #
+      # @example
+      #   require "google/gax/config"
+      #
+      #   class ServiceConfig
+      #     extend Google::Gax::Config
+      #
+      #     config_attr :host,     "localhost", String
+      #     config_attr :port,     443,         Integer
+      #     config_attr :timeout,  nil,         Numeric, nil
+      #     config_attr :metadata, nil,         Hash, nil
+      #
+      #     attr_reader :rpc_method
+      #
+      #     def initialize parent_config = nil
+      #       @parent_config = parent_config unless parent_config.nil?
+      #       @rpc_method = Google::Gax::Config::Method.new
+      #
+      #       yield self if block_given?
+      #     end
+      #   end
+      #
+      #   config = ServiceConfig.new
+      #
+      #   config.timeout = 60
+      #   config.rpc_method.timeout = 120
+      #
+      class Method
+        extend Google::Gax::Config
+
+        config_attr :timeout,      nil, Numeric, nil
+        config_attr :metadata,     nil, Hash, nil
+        config_attr :retry_policy, nil, Hash, Proc, nil
+
+        ##
+        # Create a new Config::Method object instance.
+        #
+        # @param parent_method [Google::Gax::Config::Method, nil] The config to look to values for.
+        #
+        def initialize parent_method = nil
+          @parent_config = parent_method unless parent_method.nil?
+
+          yield self if block_given?
+        end
+      end
+    end
+  end
+end

--- a/test/google/gax/config/attrs_test.rb
+++ b/test/google/gax/config/attrs_test.rb
@@ -1,0 +1,279 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require "test_helper"
+
+require "google/gax/config"
+
+class AttrsConfig
+  extend Google::Gax::Config
+
+  config_attr :str, "default str", String
+  config_attr :str_nil, nil, String, nil
+  config_attr :bool, true, true, false
+  config_attr :bool_nil, nil, true, false, nil
+  config_attr :enum, :one, :one, :two, :three
+  config_attr :opt_regex, "hi", /^[a-z]+$/
+  config_attr :opt_class, "hi", String, Symbol
+end
+
+class AttrsConfigTest < Minitest::Spec
+  def test_str
+    config = AttrsConfig.new
+    assert_equal "default str", config.str
+
+    config.str = "FooBar"
+    assert_equal "FooBar", config.str
+
+    config.str = nil
+    assert_equal "default str", config.str # reset to default
+  end
+
+  def test_str_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.str = 1
+    end
+
+    assert_raises ArgumentError do
+      config.str = true
+    end
+
+    assert_raises ArgumentError do
+      config.str = :one
+    end
+
+    assert_raises ArgumentError do
+      config.str = { hello: :world }
+    end
+  end
+
+  def test_str_nil
+    config = AttrsConfig.new
+    assert_nil config.str_nil
+
+    config.str_nil = "FooBar"
+    assert_equal "FooBar", config.str_nil
+
+    config.str_nil = nil
+    assert_nil config.str_nil
+  end
+
+  def test_str_nil_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.str_nil = 1
+    end
+
+    assert_raises ArgumentError do
+      config.str_nil = true
+    end
+
+    assert_raises ArgumentError do
+      config.str_nil = :one
+    end
+
+    assert_raises ArgumentError do
+      config.str_nil = { hello: :world }
+    end
+  end
+
+  def test_bool
+    config = AttrsConfig.new
+    assert_equal true, config.bool
+
+    config.bool = false
+    assert_equal false, config.bool
+
+    config.bool = nil
+    assert_equal true, config.bool # reset to default
+  end
+
+  def test_bool_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.bool = 1
+    end
+
+    assert_raises ArgumentError do
+      config.bool = "hi"
+    end
+
+    assert_raises ArgumentError do
+      config.bool = :one
+    end
+
+    assert_raises ArgumentError do
+      config.bool = { hello: :world }
+    end
+  end
+
+  def test_bool_nil
+    config = AttrsConfig.new
+    assert_nil config.bool_nil
+
+    config.bool_nil = true
+    assert_equal true, config.bool_nil
+
+    config.bool_nil = false
+    assert_equal false, config.bool_nil
+
+    config.bool_nil = nil
+    assert_nil config.bool_nil
+  end
+
+  def test_bool_nil_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.bool_nil = 1
+    end
+
+    assert_raises ArgumentError do
+      config.bool_nil = "hi"
+    end
+
+    assert_raises ArgumentError do
+      config.bool_nil = :one
+    end
+
+    assert_raises ArgumentError do
+      config.bool_nil = { hello: :world }
+    end
+  end
+
+  def test_enum
+    config = AttrsConfig.new
+    assert_equal :one, config.enum
+
+    config.enum = :two
+    assert_equal :two, config.enum
+
+    config.enum = :three
+    assert_equal :three, config.enum
+
+    config.enum = nil
+    assert_equal :one, config.enum # reset to default
+  end
+
+  def test_enum_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = "hi"
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.enum = { hello: :world }
+    end
+  end
+
+  def test_opt_regex
+    config = AttrsConfig.new
+    assert_equal "hi", config.opt_regex
+
+    config.opt_regex = "hello"
+    assert_equal "hello", config.opt_regex
+
+    config.opt_regex = "world"
+    assert_equal "world", config.opt_regex
+
+    config.opt_regex = nil
+    assert_equal "hi", config.opt_regex # reset to default
+  end
+
+  def test_opt_regex_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.opt_regex = "hello world"
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = "Hi"
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = "hi!"
+    end
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = { hello: :world }
+    end
+  end
+
+  def test_opt_class
+    config = AttrsConfig.new
+    assert_equal "hi", config.opt_class
+
+    config.opt_class = :hi
+    assert_equal :hi, config.opt_class
+
+    config.opt_class = "Hello World!"
+    assert_equal "Hello World!", config.opt_class
+
+    config.opt_class = nil
+    assert_equal "hi", config.opt_class # reset to default
+  end
+
+  def test_opt_class_validation
+    config = AttrsConfig.new
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.opt_class = { hello: :world }
+    end
+  end
+end

--- a/test/google/gax/config/errors_test.rb
+++ b/test/google/gax/config/errors_test.rb
@@ -1,0 +1,79 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require "test_helper"
+
+require "google/gax/config"
+
+class ConfigErrorsTest < Minitest::Test
+focus
+  def test_invalid_name
+    error = assert_raises NameError do
+      config_klass = Class.new do
+        extend Google::Gax::Config
+
+        config_attr "some method", nil, String
+      end
+    end
+    assert_equal "invalid config name some method", error.message
+  end
+focus
+  def test_parent_config
+    error = assert_raises NameError do
+      config_klass = Class.new do
+        extend Google::Gax::Config
+
+        config_attr "parent_config", nil, String
+      end
+    end
+    assert_equal "invalid config name parent_config", error.message
+  end
+focus
+  def test_existing_method
+    error = assert_raises NameError do
+      config_klass = Class.new do
+        extend Google::Gax::Config
+
+        config_attr "methods", nil, String
+      end
+    end
+    assert_equal "method methods already exists", error.message
+  end
+focus
+  def test_missing_validation
+    error = assert_raises ArgumentError do
+      config_klass = Class.new do
+        extend Google::Gax::Config
+
+        config_attr "missing_validation", nil
+      end
+    end
+    assert_equal "validation must be provided", error.message
+  end
+end

--- a/test/google/gax/config/method_test.rb
+++ b/test/google/gax/config/method_test.rb
@@ -1,0 +1,168 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require "test_helper"
+
+require "google/gax/config"
+require "google/gax/config/method"
+
+class ServiceConfig
+  extend Google::Gax::Config
+
+  config_attr :host,         "localhost", String
+  config_attr :port,         443,         Integer
+  config_attr :timeout,      60,          Numeric, nil
+  config_attr :metadata,     nil,         Hash, nil
+  config_attr :retry_policy, nil,         Hash, Proc, nil
+
+  attr_reader :rpc_method
+
+  def initialize parent_config = nil
+    @parent_config = parent_config unless parent_config.nil?
+    @rpc_method = Google::Gax::Config::Method.new parent_config&.rpc_method
+
+    yield self if block_given?
+  end
+end
+
+class MethodConfigTest < Minitest::Test
+  def test_rpc_method
+    config = ServiceConfig.new
+
+    assert_equal "localhost", config.host
+    assert_equal 443,         config.port
+    assert_equal 60,          config.timeout
+    assert_nil config.metadata
+    assert_nil config.retry_policy
+
+    assert_nil config.rpc_method.timeout
+    assert_nil config.rpc_method.metadata
+    assert_nil config.rpc_method.retry_policy
+
+    config.rpc_method.timeout = 120
+    config.rpc_method.metadata = { header: "value" }
+    config.rpc_method.retry_policy = { initial_delay: 15 }
+
+    assert_equal 120, config.rpc_method.timeout
+    assert_equal({ header: "value" }, config.rpc_method.metadata)
+    assert_equal({ initial_delay: 15 }, config.rpc_method.retry_policy)
+
+    config.rpc_method.retry_policy = ->(error) { true }
+    assert_kind_of Proc, config.rpc_method.retry_policy
+
+    config.rpc_method.timeout = nil
+    config.rpc_method.metadata = nil
+    config.rpc_method.retry_policy = nil
+
+    assert_nil config.rpc_method.timeout
+    assert_nil config.rpc_method.metadata
+    assert_nil config.rpc_method.retry_policy
+  end
+
+  def test_rpc_method_validation
+    config = ServiceConfig.new
+
+    assert_raises ArgumentError do
+      config.rpc_method.timeout = "60"
+    end
+
+    assert_raises ArgumentError do
+      config.rpc_method.metadata = ["header", "value"]
+    end
+
+    assert_raises ArgumentError do
+      config.rpc_method.retry_policy = Google::Gax::ApiCall::RetryPolicy.new
+    end
+  end
+
+  def test_nested
+    parent_config = ServiceConfig.new do |parent|
+      parent.rpc_method.timeout = 120
+      parent.rpc_method.metadata = { header: "value" }
+      parent.rpc_method.retry_policy = { initial_delay: 15 }
+    end
+    config = ServiceConfig.new parent_config
+
+    assert_equal "localhost", config.host
+    assert_equal 443,         config.port
+    assert_equal 60,          config.timeout
+
+    assert_equal 120, config.rpc_method.timeout
+    assert_equal({ header: "value" }, config.rpc_method.metadata)
+    assert_equal({ initial_delay: 15 }, config.rpc_method.retry_policy)
+
+    config.rpc_method.timeout = 90
+    config.rpc_method.metadata = { x_header: "another value" }
+    config.rpc_method.retry_policy = { initial_delay: 30 }
+
+    assert_equal 90, config.rpc_method.timeout
+    assert_equal({ x_header: "another value" }, config.rpc_method.metadata)
+    assert_equal({ initial_delay: 30 }, config.rpc_method.retry_policy)
+
+    config.rpc_method.retry_policy = ->(error) { true }
+    assert_kind_of Proc, config.rpc_method.retry_policy
+
+    config.rpc_method.timeout = nil
+    config.rpc_method.metadata = nil
+    config.rpc_method.retry_policy = nil
+
+    assert_equal 120, config.rpc_method.timeout
+    assert_equal({ header: "value" }, config.rpc_method.metadata)
+    assert_equal({ initial_delay: 15 }, config.rpc_method.retry_policy)
+
+    parent_config.rpc_method.timeout = nil
+    parent_config.rpc_method.metadata = nil
+    parent_config.rpc_method.retry_policy = nil
+
+    assert_nil parent_config.rpc_method.timeout
+    assert_nil parent_config.rpc_method.metadata
+    assert_nil parent_config.rpc_method.retry_policy
+  end
+
+  def test_nested_validation
+    parent_config = ServiceConfig.new do |parent|
+      parent.rpc_method.timeout = 120
+      parent.rpc_method.metadata = { header: "value" }
+      parent.rpc_method.retry_policy = { initial_delay: 15 }
+    end
+    config = ServiceConfig.new parent_config
+
+    assert_raises ArgumentError do
+      config.rpc_method.timeout = "60"
+    end
+
+    assert_raises ArgumentError do
+      config.rpc_method.metadata = ["header", "value"]
+    end
+
+    assert_raises ArgumentError do
+      config.rpc_method.retry_policy = Google::Gax::ApiCall::RetryPolicy.new
+    end
+  end
+end

--- a/test/google/gax/config/nested_test.rb
+++ b/test/google/gax/config/nested_test.rb
@@ -1,0 +1,238 @@
+# Copyright 2019, Google LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require "test_helper"
+
+require "google/gax/config"
+
+class NestedConfig
+  extend Google::Gax::Config
+
+  config_attr :str, "default str", String
+  config_attr :str_nil, nil, String, nil
+  config_attr :bool, true, true, false
+  config_attr :bool_nil, nil, true, false, nil
+  config_attr :enum, :one, :one, :two, :three
+  config_attr :opt_regex, "hi", /^[a-z]+$/
+  config_attr :opt_class, "hi", String, Symbol
+
+  def initialize parent_config = nil
+    @parent_config = parent_config unless parent_config.nil?
+    yield self if block_given?
+  end
+end
+
+class NestedConfigTest < Minitest::Spec
+  def setup
+    @parent_config = NestedConfig.new do |config|
+      config.str = "updated str"
+      config.bool = false
+      config.enum = :two
+      config.opt_regex = "hello"
+      config.opt_class = :hi
+    end
+  end
+
+  def test_str
+    config = NestedConfig.new @parent_config
+    assert_equal "updated str", config.str
+
+    config.str = "FooBar"
+    assert_equal "FooBar", config.str
+
+    config.str = nil
+    assert_equal "updated str", config.str # reset to parent
+
+    @parent_config.str = nil
+    assert_equal "default str", config.str # reset to default
+  end
+
+  def test_str_validation
+    config = NestedConfig.new @parent_config
+
+    assert_raises ArgumentError do
+      config.str = 1
+    end
+
+    assert_raises ArgumentError do
+      config.str = true
+    end
+
+    assert_raises ArgumentError do
+      config.str = :one
+    end
+
+    assert_raises ArgumentError do
+      config.str = { hello: :world }
+    end
+  end
+
+  def test_bool
+    config = NestedConfig.new @parent_config
+    assert_equal false, config.bool
+
+    config.bool = true
+    assert_equal true, config.bool
+
+    config.bool = nil
+    assert_equal false, config.bool # reset to parent
+
+    @parent_config.bool = nil
+    assert_equal true, config.bool # reset to default
+  end
+
+  def test_bool_validation
+    config = NestedConfig.new @parent_config
+
+    assert_raises ArgumentError do
+      config.bool = 1
+    end
+
+    assert_raises ArgumentError do
+      config.bool = "hi"
+    end
+
+    assert_raises ArgumentError do
+      config.bool = :one
+    end
+
+    assert_raises ArgumentError do
+      config.bool = { hello: :world }
+    end
+  end
+
+  def test_enum
+    config = NestedConfig.new @parent_config
+    assert_equal :two, config.enum
+
+    config.enum = :one
+    assert_equal :one, config.enum
+
+    config.enum = :three
+    assert_equal :three, config.enum
+
+    config.enum = nil
+    assert_equal :two, config.enum # reset to parent
+
+    @parent_config.enum = nil
+    assert_equal :one, config.enum # reset to default
+  end
+
+  def test_enum_validation
+    config = NestedConfig.new @parent_config
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = "hi"
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.enum = { hello: :world }
+    end
+  end
+
+  def test_opt_regex
+    config = NestedConfig.new @parent_config
+    assert_equal "hello", config.opt_regex
+
+    config.opt_regex = "world"
+    assert_equal "world", config.opt_regex
+
+    config.opt_regex = nil
+    assert_equal "hello", config.opt_regex # reset to parent
+
+    @parent_config.opt_regex = nil
+    assert_equal "hi", config.opt_regex # reset to default
+  end
+
+  def test_opt_regex_validation
+    config = NestedConfig.new @parent_config
+
+    assert_raises ArgumentError do
+      config.opt_regex = "hello world"
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = "Hi"
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = "hi!"
+    end
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.opt_regex = { hello: :world }
+    end
+  end
+
+  def test_opt_class
+    config = NestedConfig.new @parent_config
+    assert_equal :hi, config.opt_class
+
+    config.opt_class = "Hello World!"
+    assert_equal "Hello World!", config.opt_class
+
+    config.opt_class = nil
+    assert_equal :hi, config.opt_class # reset to parent
+
+    @parent_config.opt_class = nil
+    assert_equal "hi", config.opt_class # reset to default
+  end
+
+  def test_opt_class_validation
+    config = NestedConfig.new @parent_config
+
+    assert_raises ArgumentError do
+      config.enum = 1
+    end
+
+    assert_raises ArgumentError do
+      config.enum = true
+    end
+
+    assert_raises ArgumentError do
+      config.opt_class = { hello: :world }
+    end
+  end
+end


### PR DESCRIPTION
This PR is an alternate implementation of the Configuration library. It provides a single module that clients can use to easily create a `Configuration` class. It is parent aware, so nested/child configuration objects can be created that will look to the parent object for values when local values are not present.