### PR TITLE
Defer runtime dependency on gRPC

### DIFF
--- a/lib/google/gax/errors.rb
+++ b/lib/google/gax/errors.rb
@@ -27,9 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require "English"
-require "google/gax/grpc"
-
 module Google
   module Gax
     # Common base class for exceptions raised by GAX.


### PR DESCRIPTION
We don't want to load the code with runtime dependency on grpc until
grpc has been loaded. This also resolves a circular require warning.