### PR TITLE
Make headers on operations client injectable

### DIFF
--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -114,7 +114,8 @@ module Google
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
           lib_name: nil,
-          lib_version: ""
+          lib_version: "",
+          _headers: {}
         # These require statements are intentionally placed here to initialize
         # the gRPC module only when it's required.
         # See https://github.com/googleapis/toolkit/issues/446
@@ -147,7 +148,7 @@ module Google
         google_api_client << " grpc/#{GRPC::VERSION}"
         google_api_client.freeze
 
-        headers = { :"x-goog-api-client" => google_api_client }
+        headers = { :"x-goog-api-client" => google_api_client }.merge(_headers)
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"
         )


### PR DESCRIPTION
For Google Ads we send additional headers for LRO reloads, specifically:

```
developer-token
login-customer-id
```

without these headers being injectable it's not possible for us to
complete LRO calls successfully. This patch exposes headers in the
constructor of the operations client so that we can pass these when we
construct our operations client objects.