### PR TITLE
Allow Signet::OAuth2::Client as credential arg

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Exclude:
     - "lib/google/gax/config.rb"
+    - "lib/google/gax/grpc/stub.rb"
 
 Style/Documentation:
   Exclude:


### PR DESCRIPTION
Google Cloud supports `Signet::OAuth2::Client` as a credentials argument now. The `Credentials` class was originally intended to be a factory for creating `Signet::OAuth2::Client` objects, so it makes sense to support these objects.

GAPIC Generator adds support for this class to the configuration in googleapis/gapic-generator-ruby#151.