### PR TITLE
Add OperationsClient metadata argument

### DIFF
--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -1,4 +1,4 @@
-# Copyright 2016, Google LLC
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -11,7 +11,7 @@
 # copyright notice, this list of conditions and the following disclaimer
 # in the documentation and/or other materials provided with the
 # distribution.
-#     * Neither the name of Google LLC nor the names of its
+#     * Neither the name of Google Inc. nor the names of its
 # contributors may be used to endorse or promote products derived from
 # this software without specific prior written permission.
 #
@@ -125,7 +125,8 @@ module Google
                        options.page_token
                      end
 
-        metadata = @metadata.dup || {}
+        metadata = @metadata || {}
+        metadata = metadata.dup
         metadata.update(options.metadata) if options.metadata != :OPTION_INHERIT
 
         CallSettings.new(timeout: timeout,

--- a/lib/google/gax/settings.rb
+++ b/lib/google/gax/settings.rb
@@ -1,4 +1,4 @@
-# Copyright 2016, Google Inc.
+# Copyright 2016, Google LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -11,7 +11,7 @@
 # copyright notice, this list of conditions and the following disclaimer
 # in the documentation and/or other materials provided with the
 # distribution.
-#     * Neither the name of Google Inc. nor the names of its
+#     * Neither the name of Google LLC nor the names of its
 # contributors may be used to endorse or promote products derived from
 # this software without specific prior written permission.
 #

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -142,14 +142,14 @@ module Google
           updater_proc = credentials.updater_proc
         end
 
-        google_api_client = "gl-ruby/#{RUBY_VERSION}"
-        google_api_client << " #{lib_name}/#{lib_version}" if lib_name
-        google_api_client << " gax/#{Google::Gax::VERSION}"
-        google_api_client << " grpc/#{GRPC::VERSION}"
-        google_api_client.freeze
-
         metadata ||= {}
-        metadata[:"x-goog-api-client"] ||= google_api_client
+        metadata[:"x-goog-api-client"] ||= begin
+          google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
+          google_api_client << "#{lib_name}/#{lib_version}" if lib_name
+          google_api_client << "gax/#{Google::Gax::VERSION}"
+          google_api_client << "grpc/#{GRPC::VERSION}"
+          google_api_client.join(' ')
+        end
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"
         )

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -142,11 +142,9 @@ module Google
           updater_proc = credentials.updater_proc
         end
 
-        package_version = Gem.loaded_specs['google-gax'].version.version
-
         google_api_client = "gl-ruby/#{RUBY_VERSION}"
         google_api_client << " #{lib_name}/#{lib_version}" if lib_name
-        google_api_client << " gapic/#{package_version} gax/#{Google::Gax::VERSION}"
+        google_api_client << " gax/#{Google::Gax::VERSION}"
         google_api_client << " grpc/#{GRPC::VERSION}"
         google_api_client.freeze
 

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -150,9 +150,11 @@ module Google
           google_api_client << "grpc/#{GRPC::VERSION}"
           google_api_client.join(' ')
         end
+
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"
         )
+
         defaults = client_config_file.open do |f|
           Google::Gax.construct_settings(
             "google.longrunning.Operations",

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -164,7 +164,7 @@ module Google
             timeout,
             page_descriptors: PAGE_DESCRIPTORS,
             errors: Google::Gax::Grpc::API_ERRORS,
-            kwargs: metadata
+            metadata: metadata
           )
         end
 

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -108,13 +108,16 @@ module Google
       #   or the specified config is missing data points.
       # @param timeout [Numeric]
       #   The default timeout, in seconds, for calls made through this client.
+      # @param metadata [Hash]
+      #   The request metadata headers.
       def initialize \
           credentials: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
           lib_name: nil,
-          lib_version: ""
+          lib_version: "",
+          metadata: nil
         # These require statements are intentionally placed here to initialize
         # the gRPC module only when it's required.
         # See https://github.com/googleapis/toolkit/issues/446
@@ -147,7 +150,8 @@ module Google
         google_api_client << " grpc/#{GRPC::VERSION}"
         google_api_client.freeze
 
-        headers = { :"x-goog-api-client" => google_api_client }
+        metadata ||= {}
+        metadata[:"x-goog-api-client"] ||= google_api_client
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"
         )
@@ -160,7 +164,7 @@ module Google
             timeout,
             page_descriptors: PAGE_DESCRIPTORS,
             errors: Google::Gax::Grpc::API_ERRORS,
-            kwargs: headers
+            kwargs: metadata
           )
         end
 

--- a/lib/google/longrunning/operations_client.rb
+++ b/lib/google/longrunning/operations_client.rb
@@ -148,7 +148,7 @@ module Google
           google_api_client << "#{lib_name}/#{lib_version}" if lib_name
           google_api_client << "gax/#{Google::Gax::VERSION}"
           google_api_client << "grpc/#{GRPC::VERSION}"
-          google_api_client.join(' ')
+          google_api_client.join(' ').freeze
         end
 
         client_config_file = Pathname.new(__dir__).join(


### PR DESCRIPTION
This PR is an alternate version of #200 that adds an argument to specify GRPC headers to be sent with the `OperationsClient` calls.