### PR TITLE
Refactor Gax::GRPC::Stub to a class

### DIFF
--- a/lib/google/gax/grpc/stub.rb
+++ b/lib/google/gax/grpc/stub.rb
@@ -39,13 +39,16 @@ module Google
       #
       # This class wraps the actual gRPC Stub object and it's RPC methods.
       #
+      # @!attribute [r] grpc_stub
+      #   @return [Object] The instance of the gRPC stub class (`grpc_stub_class`) constructor argument.
+      #
       class Stub
-        attr_reader :stub
+        attr_reader :grpc_stub
 
         ##
         # Creates a Gax gRPC stub object.
         #
-        # @param stub_class [Class] gRPC stub class to create a new instance of.
+        # @param grpc_stub_class [Class] gRPC stub class to create a new instance of.
         # @param host [String] The domain name of the API remote host.
         # @param port [Fixnum] The port on which to connect to the remote host.
         # @param credentials [Google::Auth::Credentials, Signet::OAuth2::Client, String, Hash, Proc,
@@ -65,8 +68,8 @@ module Google
         # @param interceptors [Array<GRPC::ClientInterceptor>] An array of {GRPC::ClientInterceptor} objects that will
         #   be used for intercepting calls before they are executed Interceptors are an EXPERIMENTAL API.
         #
-        def initialize stub_class, host:, port:, credentials:, channel_args: nil, interceptors: nil
-          raise ArgumentError, "stub_class is required" if stub_class.nil?
+        def initialize grpc_stub_class, host:, port:, credentials:, channel_args: nil, interceptors: nil
+          raise ArgumentError, "grpc_stub_class is required" if grpc_stub_class.nil?
           raise ArgumentError, "host is required" if host.nil?
           raise ArgumentError, "port is required" if port.nil?
           raise ArgumentError, "credentials is required" if credentials.nil?
@@ -75,19 +78,22 @@ module Google
           channel_args = Hash channel_args
           interceptors = Array interceptors
 
-          @stub = if credentials.is_a? GRPC::Core::Channel
-                    stub_class.new address, nil, channel_override: credentials, interceptors: interceptors
-                  elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                    stub_class.new address, credentials, channel_args: channel_args, interceptors: interceptors
-                  else
-                    updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
-                    updater_proc ||= credentials if credentials.is_a? Proc
-                    raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
+          @grpc_stub = if credentials.is_a? GRPC::Core::Channel
+                         grpc_stub_class.new address, nil, channel_override: credentials,
+                                                           interceptors:     interceptors
+                       elsif credentials.is_a? GRPC::Core::ChannelCredentials
+                         grpc_stub_class.new address, credentials, channel_args: channel_args,
+                                                                   interceptors: interceptors
+                       else
+                         updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
+                         updater_proc ||= credentials if credentials.is_a? Proc
+                         raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
 
-                    call_creds = GRPC::Core::CallCredentials.new updater_proc
-                    chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
-                    stub_class.new address, chan_creds, channel_args: channel_args, interceptors: interceptors
-                  end
+                         call_creds = GRPC::Core::CallCredentials.new updater_proc
+                         chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
+                         grpc_stub_class.new address, chan_creds, channel_args: channel_args,
+                                                                  interceptors: interceptors
+                       end
         end
 
         ##
@@ -177,7 +183,7 @@ module Google
         #
         def call_rpc method_name, request, options: nil, format_response: nil, operation_callback: nil,
                      stream_callback: nil
-          api_call = Google::Gax::ApiCall.new @stub.method method_name
+          api_call = Google::Gax::ApiCall.new @grpc_stub.method method_name
           api_call.call request, options:            options,
                                  format_response:    format_response,
                                  operation_callback: operation_callback,

--- a/lib/google/gax/grpc/stub.rb
+++ b/lib/google/gax/grpc/stub.rb
@@ -29,16 +29,21 @@
 
 require "grpc"
 require "googleauth"
+require "google/gax/api_call"
 
 module Google
   module Gax
     module Grpc
       ##
-      # Stub
-      # TODO: Add documentation
-      module Stub
+      # Gax gRPC Stub
+      #
+      # This class wraps the actual gRPC Stub object and it's RPC methods.
+      #
+      class Stub
+        attr_reader :stub
+
         ##
-        # Creates a gRPC stub object.
+        # Creates a Gax gRPC stub object.
         #
         # @param stub_class [Class] gRPC stub class to create a new instance of.
         # @param host [String] The domain name of the API remote host.
@@ -60,9 +65,7 @@ module Google
         # @param interceptors [Array<GRPC::ClientInterceptor>] An array of {GRPC::ClientInterceptor} objects that will
         #   be used for intercepting calls before they are executed Interceptors are an EXPERIMENTAL API.
         #
-        # @return The gRPC stub object.
-        #
-        def self.new stub_class, host:, port:, credentials:, channel_args: nil, interceptors: nil
+        def initialize stub_class, host:, port:, credentials:, channel_args: nil, interceptors: nil
           raise ArgumentError, "stub_class is required" if stub_class.nil?
           raise ArgumentError, "host is required" if host.nil?
           raise ArgumentError, "port is required" if port.nil?
@@ -72,19 +75,113 @@ module Google
           channel_args = Hash channel_args
           interceptors = Array interceptors
 
-          if credentials.is_a? GRPC::Core::Channel
-            return stub_class.new address, nil, channel_override: credentials, interceptors: interceptors
-          elsif credentials.is_a? GRPC::Core::ChannelCredentials
-            return stub_class.new address, credentials, channel_args: channel_args, interceptors: interceptors
-          end
+          @stub = if credentials.is_a? GRPC::Core::Channel
+                    stub_class.new address, nil, channel_override: credentials, interceptors: interceptors
+                  elsif credentials.is_a? GRPC::Core::ChannelCredentials
+                    stub_class.new address, credentials, channel_args: channel_args, interceptors: interceptors
+                  else
+                    updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
+                    updater_proc ||= credentials if credentials.is_a? Proc
+                    raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
 
-          updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
-          updater_proc ||= credentials if credentials.is_a? Proc
-          raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
+                    call_creds = GRPC::Core::CallCredentials.new updater_proc
+                    chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
+                    stub_class.new address, chan_creds, channel_args: channel_args, interceptors: interceptors
+                  end
+        end
 
-          call_creds = GRPC::Core::CallCredentials.new updater_proc
-          chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
-          stub_class.new address, chan_creds, channel_args: channel_args, interceptors: interceptors
+        ##
+        # Invoke the specified API call.
+        #
+        # @param method_name [Symbol] The RPC method name.
+        # @param request [Object] The request object.
+        # @param options [ApiCall::Options, Hash] The options for making the API call. A Hash can be provided to
+        #   customize the options object, using keys that match the arguments for {ApiCall::Options.new}. This object
+        #   should only be used once.
+        # @param format_response [Proc] A Proc object to format the response object. The Proc should accept response as
+        #   an argument, and return a formatted response object. Optional.
+        #
+        #   If `stream_callback` is also provided, the response argument will be an Enumerable of the responses.
+        #   Returning a lazy enumerable that adds the desired formatting is recommended.
+        # @param operation_callback [Proc] A Proc object to provide a callback of the response and operation objects.
+        #   The response will be formatted with `format_response` if that is also provided. Optional.
+        # @param stream_callback [Proc] A Proc object to provide a callback for every streamed response received. The
+        #   Proc will be called with the response object. Should only be used on Bidi and Server streaming RPC calls.
+        #   Optional.
+        #
+        # @return [Object, Thread] The response object. Or, when `stream_callback` is provided, a thread running the
+        #   callback for every streamed response is returned.
+        #
+        # @example
+        #   require "google/showcase/v1alpha3/echo_pb"
+        #   require "google/showcase/v1alpha3/echo_services_pb"
+        #   require "google/gax"
+        #   require "google/gax/grpc"
+        #
+        #   echo_channel = GRPC::Core::Channel.new(
+        #     "localhost:7469", nil, :this_channel_is_insecure
+        #   )
+        #   echo_stub = Google::Gax::Grpc::Stub.new(
+        #     Google::Showcase::V1alpha3::Echo::Stub,
+        #     host: "localhost", port: 7469, credentials: echo_channel
+        #   )
+        #
+        #   request = Google::Showcase::V1alpha3::EchoRequest.new
+        #   response = echo_stub.call_rpc :echo, request
+        #
+        # @example Using custom call options:
+        #   require "google/showcase/v1alpha3/echo_pb"
+        #   require "google/showcase/v1alpha3/echo_services_pb"
+        #   require "google/gax"
+        #   require "google/gax/grpc"
+        #
+        #   echo_channel = GRPC::Core::Channel.new(
+        #     "localhost:7469", nil, :this_channel_is_insecure
+        #   )
+        #   echo_stub = Google::Gax::Grpc::Stub.new(
+        #     Google::Showcase::V1alpha3::Echo::Stub,
+        #     host: "localhost", port: 7469, credentials: echo_channel
+        #   )
+        #
+        #   request = Google::Showcase::V1alpha3::EchoRequest.new
+        #   options = Google::Gax::ApiCall::Options.new(
+        #     retry_policy = {
+        #       retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+        #     }
+        #   )
+        #   response = echo_stub.call_rpc :echo, request
+        #                                 options: options
+        #
+        # @example Formatting the response in the call:
+        #   require "google/showcase/v1alpha3/echo_pb"
+        #   require "google/showcase/v1alpha3/echo_services_pb"
+        #   require "google/gax"
+        #   require "google/gax/grpc"
+        #
+        #   echo_channel = GRPC::Core::Channel.new(
+        #     "localhost:7469", nil, :this_channel_is_insecure
+        #   )
+        #   echo_stub = Google::Gax::Grpc::Stub.new(
+        #     Google::Showcase::V1alpha3::Echo::Stub,
+        #     host: "localhost", port: 7469, credentials: echo_channel
+        #   )
+        #
+        #   request = Google::Showcase::V1alpha3::EchoRequest.new
+        #   content_upcaser = proc do |response|
+        #     format_response = response.dup
+        #     format_response.content.upcase!
+        #     format_response
+        #   end
+        #   response = echo_stub.call_rpc :echo, request,
+        #                                 format_response: content_upcaser
+        #
+        def call_rpc method_name, request, options: nil, format_response: nil, operation_callback: nil,
+                     stream_callback: nil
+          api_call = Google::Gax::ApiCall.new @stub.method method_name
+          api_call.call request, options:            options,
+                                 format_response:    format_response,
+                                 operation_callback: operation_callback,
+                                 stream_callback:    stream_callback
         end
       end
     end

--- a/lib/google/gax/paged_enumerable.rb
+++ b/lib/google/gax/paged_enumerable.rb
@@ -64,14 +64,17 @@ module Google
       attr_reader :page
 
       ##
-      # @param request_page_token_field [String] The name of the field in request which will have the page token.
-      # @param response_page_token_field [String] The name of the field in the response which holds the next page token.
-      # @param resource_field [String] The name of the field in the response which holds the resources.
+      # @param grpc_stub [Gax::GRPC::Stub] The Gax gRPC stub object.
+      # @param method_name [Symbol] The RPC method name.
+      # @param request [Object] The request object.
+      # @param response [Object] The response object.
+      # @param options [ApiCall::Options] The options for making the API call.
       # @param format_resource [Proc] A Proc object to format the resource object. The Proc should accept response as an
       #   argument, and return a formatted resource object. Optional.
       #
-      def initialize api_call, request, response, options, format_resource: nil
-        @api_call = api_call
+      def initialize grpc_stub, method_name, request, response, options, format_resource: nil
+        @grpc_stub = grpc_stub
+        @method_name = method_name
         @request = request
         @response = response
         @options = options
@@ -137,7 +140,7 @@ module Google
 
         next_request = @request.dup
         next_request.page_token = @page.next_page_token
-        next_response = @api_call.call next_request, options: @options
+        next_response = @grpc_stub.call_rpc @method_name, next_request, options: @options
 
         @page = Page.new next_response, @resource_field
       end


### PR DESCRIPTION
Implement calling the RPC by calling a method on the Stub object instead of creating an ApiCall object. This allows us to fix the code that calls APIs in Gax instead of in the generator.

Generator support added in googleapis/gapic-generator-ruby#152.