### PR TITLE
Call GAPIC client using positional args

### DIFF
--- a/lib/google/gax/operation.rb
+++ b/lib/google/gax/operation.rb
@@ -214,7 +214,7 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        @client.cancel_operation name: @grpc_op.name, options: options
+        @client.cancel_operation({ name: @grpc_op.name }, options)
       end
 
       ##
@@ -227,7 +227,7 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        @client.delete_operation name: @grpc_op.name, options: options
+        @client.delete_operation({ name: @grpc_op.name }, options)
       end
 
       ##
@@ -242,7 +242,7 @@ module Google
         # Converts hash and nil to an options object
         options = ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
-        gax_op = @client.get_operation name: @grpc_op.name, options: options
+        gax_op = @client.get_operation({ name: @grpc_op.name }, options)
         @grpc_op = gax_op.grpc_op
 
         if done?


### PR DESCRIPTION
This PR changes the Operations calls to the Operations Client to use positional arguments instead of the mixed positional/named arguments. This is needed to work around Protobuf [adding the `#to_hash` method to the resource classes](https://github.com/protocolbuffers/protobuf/pull/6166).

The generator side of this change is in googleapis/gapic-generator-ruby#155.