### PR TITLE
Add tests for recent changes

### DIFF
--- a/test/google/gax/config/errors_test.rb
+++ b/test/google/gax/config/errors_test.rb
@@ -32,7 +32,6 @@ require "test_helper"
 require "google/gax/config"
 
 class ConfigErrorsTest < Minitest::Test
-focus
   def test_invalid_name
     error = assert_raises NameError do
       config_klass = Class.new do
@@ -43,7 +42,7 @@ focus
     end
     assert_equal "invalid config name some method", error.message
   end
-focus
+
   def test_parent_config
     error = assert_raises NameError do
       config_klass = Class.new do
@@ -54,7 +53,7 @@ focus
     end
     assert_equal "invalid config name parent_config", error.message
   end
-focus
+
   def test_existing_method
     error = assert_raises NameError do
       config_klass = Class.new do
@@ -65,7 +64,7 @@ focus
     end
     assert_equal "method methods already exists", error.message
   end
-focus
+
   def test_missing_validation
     error = assert_raises ArgumentError do
       config_klass = Class.new do

--- a/test/google/gax/grpc/stub_test.rb
+++ b/test/google/gax/grpc/stub_test.rb
@@ -78,7 +78,7 @@ class GrpcStubTest < Minitest::Spec
 
     mock = Minitest::Mock.new
     mock.expect :nil?, false
-    mock.expect :new, nil, ["service:port", fake_channel_creds, interceptors: []]
+    mock.expect :new, nil, ["service:port", fake_channel_creds, channel_args: {}, interceptors: []]
 
     Google::Gax::Grpc::Stub.new mock, host: "service", port: "port", credentials: fake_channel_creds
 
@@ -90,7 +90,7 @@ class GrpcStubTest < Minitest::Spec
       GRPC::Core::ChannelCredentials.stub :new, FakeChannelCredentials.method(:new) do
         mock = Minitest::Mock.new
         mock.expect :nil?, false
-        mock.expect :new, nil, ["service:port", FakeCallCredentials, interceptors: []]
+        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: []]
 
         Google::Gax::Grpc::Stub.new mock, host: "service", port: "port", credentials: FakeCredentials.new
 
@@ -104,7 +104,7 @@ class GrpcStubTest < Minitest::Spec
       GRPC::Core::ChannelCredentials.stub :new, FakeChannelCredentials.method(:new) do
         mock = Minitest::Mock.new
         mock.expect :nil?, false
-        mock.expect :new, nil, ["service:port", FakeCallCredentials, interceptors: []]
+        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: []]
 
         credentials_proc = ->{}
 

--- a/test/google/gax/operation_test.rb
+++ b/test/google/gax/operation_test.rb
@@ -45,17 +45,17 @@ class MockLroClient
     @delete_method = delete_method
   end
 
-  def get_operation name:, options: nil
-    grpc_op = @get_method.call name: name, options: options
+  def get_operation request, options = nil
+    grpc_op = @get_method.call name: request[:name], options: options
     Google::Gax::Operation.new grpc_op, self
   end
 
-  def cancel_operation name:, options: nil
-    @cancel_method.call name: name, options: options
+  def cancel_operation request, options = nil
+    @cancel_method.call name: request[:name], options: options
   end
 
-  def delete_operation name:, options: nil
-    @delete_method.call name: name, options: options
+  def delete_operation request, options = nil
+    @delete_method.call name: request[:name], options: options
   end
 end
 

--- a/test/google/gax/paged_enumerable/enum_test.rb
+++ b/test/google/gax/paged_enumerable/enum_test.rb
@@ -30,6 +30,15 @@
 require "test_helper"
 
 describe Google::Gax::PagedEnumerable, :enumerable do
+  class FakeGaxStub
+    def initialize *responses
+      @responses = responses
+    end
+    def call_rpc *args
+      @responses.shift
+    end
+  end
+
   it "enumerates all resources" do
     api_responses = [
       Google::Gax::GoodPagedResponse.new(
@@ -39,7 +48,7 @@ describe Google::Gax::PagedEnumerable, :enumerable do
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -50,7 +59,7 @@ describe Google::Gax::PagedEnumerable, :enumerable do
     )
     options = Google::Gax::ApiCall::Options.new
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options
+      gax_stub, :method_name, request, response, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.each.map(&:name)
@@ -65,7 +74,7 @@ describe Google::Gax::PagedEnumerable, :enumerable do
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -76,7 +85,7 @@ describe Google::Gax::PagedEnumerable, :enumerable do
     )
     options = Google::Gax::ApiCall::Options.new
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options
+      gax_stub, :method_name, request, response, options
     )
 
     assert_equal [2, 2], paged_enum.each_page.map(&:count)

--- a/test/google/gax/paged_enumerable/format_resource_test.rb
+++ b/test/google/gax/paged_enumerable/format_resource_test.rb
@@ -30,6 +30,15 @@
 require "test_helper"
 
 describe Google::Gax::PagedEnumerable, :format_resource do
+  class FakeGaxStub
+    def initialize *responses
+      @responses = responses
+    end
+    def call_rpc *args
+      @responses.shift
+    end
+  end
+
   it "enumerates all resources and formats them" do
     api_responses = [
       Google::Gax::GoodPagedResponse.new(
@@ -39,7 +48,7 @@ describe Google::Gax::PagedEnumerable, :format_resource do
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -51,7 +60,7 @@ describe Google::Gax::PagedEnumerable, :format_resource do
     options = Google::Gax::ApiCall::Options.new
     upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
     )
 
     assert_equal ["FOO", "BAR", "BAZ", "BIF"], paged_enum.each.to_a
@@ -66,7 +75,7 @@ describe Google::Gax::PagedEnumerable, :format_resource do
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -78,7 +87,7 @@ describe Google::Gax::PagedEnumerable, :format_resource do
     options = Google::Gax::ApiCall::Options.new
     upcase_resource = ->(str) { str.upcase }
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
     )
 
     page_proc = ->(page) { page.each.map(&:name) }

--- a/test/google/gax/paged_enumerable/invalid_request_test.rb
+++ b/test/google/gax/paged_enumerable/invalid_request_test.rb
@@ -31,14 +31,13 @@ require "test_helper"
 
 class PagedEnumerableInvalidRequestTest < Minitest::Test
   def test_MissingPageTokenRequest
-    api_call = -> {}
     request = Google::Gax::MissingPageTokenRequest.new
     response = Google::Gax::GoodPagedResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{request.class} must have a page_token field (String)"
@@ -46,14 +45,13 @@ class PagedEnumerableInvalidRequestTest < Minitest::Test
   end
 
   def test_MissingPageSizeRequest
-    api_call = -> {}
     request = Google::Gax::MissingPageSizeRequest.new
     response = Google::Gax::GoodPagedResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{request.class} must have a page_size field (Integer)"

--- a/test/google/gax/paged_enumerable/invalid_response_test.rb
+++ b/test/google/gax/paged_enumerable/invalid_response_test.rb
@@ -31,14 +31,13 @@ require "test_helper"
 
 class PagedEnumerableInvalidResponseTest < Minitest::Test
   def test_MissingRepeatedResponse
-    api_call = -> {}
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::MissingRepeatedResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -46,14 +45,13 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
   end
 
   def test_MissingMessageResponse
-    api_call = -> {}
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::MissingMessageResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -61,14 +59,13 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
   end
 
   def test_MissingNextPageTokenResponse
-    api_call = -> {}
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::MissingNextPageTokenResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{response.class} must have a next_page_token field (String)"
@@ -78,14 +75,13 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
   def test_BadMessageOrderResponse
     skip "Looks like fields are already sorted by number, not proto order"
 
-    api_call = -> {}
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::BadMessageOrderResponse.new
     options = Google::Gax::ApiCall::Options.new
 
     error = assert_raises ArgumentError do
       Google::Gax::PagedEnumerable.new(
-        api_call, request, response, options
+        Object.new, :method_name, request, response, options
       )
     end
     exp_msg = "#{response.class} must have one primary repeated field " \

--- a/test/google/gax/paged_enumerable/valid_request_response_test.rb
+++ b/test/google/gax/paged_enumerable/valid_request_response_test.rb
@@ -30,6 +30,15 @@
 require "test_helper"
 
 class PagedEnumerableValidRequestResponseTest < Minitest::Test
+  class FakeGaxStub
+    def initialize *responses
+      @responses = responses
+    end
+    def call_rpc *args
+      @responses.shift
+    end
+  end
+
   def test_GoodPagedRequest_GoodPagedResponse
     api_responses = [
       Google::Gax::GoodPagedResponse.new(
@@ -39,7 +48,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::GoodPagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -50,7 +59,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Google::Gax::ApiCall::Options.new
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options
+      gax_stub, :method_name, request, response, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)
@@ -65,7 +74,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
         ]
       )
     ]
-    api_call = ->(_req, _opt) { api_responses.shift }
+    gax_stub = FakeGaxStub.new *api_responses
     request = Google::Gax::Int64PagedRequest.new
     response = Google::Gax::GoodPagedResponse.new(
       users:           [
@@ -76,7 +85,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Google::Gax::ApiCall::Options.new
     paged_enum = Google::Gax::PagedEnumerable.new(
-      api_call, request, response, options
+      gax_stub, :method_name, request, response, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)


### PR DESCRIPTION
I mistakenly thought our test coverage was worse than it is. In fact, we had some errant `focus` calls that prevented the other tests from being run. When they were removed many recent features required changes to their tests.