### PR TITLE
Add headers helpers

### DIFF
--- a/lib/google/gax/headers.rb
+++ b/lib/google/gax/headers.rb
@@ -27,18 +27,33 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require "google/gax/api_call"
-require "google/gax/configuration"
-require "google/gax/errors"
-require "google/gax/headers"
-require "google/gax/operation"
-require "google/gax/paged_enumerable"
-require "google/gax/protobuf"
-require "google/gax/stream_input"
-require "google/gax/version"
+require "google/gax/operation/retry_policy"
+require "google/protobuf/well_known_types"
 
 module Google
-  # Gax defines Google API extensions
   module Gax
+    # A collection of common header values.
+    module Headers
+      ##
+      # @param ruby_version [String] The ruby version. Defaults to `RUBY_VERSION`.
+      # @param lib_name [String] The client library name.
+      # @param lib_version [String] The client library version.
+      # @param gapic_version [String] The GAPIC client version.
+      # @param gax_version [String] The Gax version. Defaults to `Google::Gax::VERSION`.
+      # @param grpc_version [String] The GRPC version. Defaults to `GRPC::VERSION`.
+      def self.x_goog_api_client ruby_version: nil, lib_name: nil, lib_version: nil,
+                                 gapic_version: nil, gax_version: nil, grpc_version: nil
+        ruby_version ||= ::RUBY_VERSION
+        gax_version  ||= ::Google::Gax::VERSION
+        grpc_version ||= ::GRPC::VERSION if defined? ::GRPC
+
+        x_goog_api_client_header = ["gl-ruby/#{ruby_version}"]
+        x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+        x_goog_api_client_header << "gapic/#{gapic_version}" if gapic_version
+        x_goog_api_client_header << "gax/#{gax_version}"
+        x_goog_api_client_header << "grpc/#{grpc_version}" if grpc_version
+        x_goog_api_client_header.join " ".freeze
+      end
+    end
   end
 end

--- a/lib/google/gax/headers.rb
+++ b/lib/google/gax/headers.rb
@@ -1,4 +1,4 @@
-# Copyright 2016, Google LLC
+# Copyright 2019, Google LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/test/google/gax/headers/x_goog_api_client_test.rb
+++ b/test/google/gax/headers/x_goog_api_client_test.rb
@@ -31,22 +31,21 @@ require "test_helper"
 require "grpc"
 
 describe Google::Gax::Headers, :x_goog_api_client do
-  focus
   it "with no arguments" do
     header = Google::Gax::Headers.x_goog_api_client
     _(header).must_equal "gl-ruby/#{RUBY_VERSION} gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
   end
-  focus
+
   it "prints lib when provided" do
     header = Google::Gax::Headers.x_goog_api_client lib_name: "foo", lib_version: "bar"
     _(header).must_equal "gl-ruby/#{RUBY_VERSION} foo/bar gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
   end
-  focus
+
   it "prints gapic version when provided" do
     header = Google::Gax::Headers.x_goog_api_client gapic_version: "foobar"
     _(header).must_equal "gl-ruby/#{RUBY_VERSION} gapic/foobar gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
   end
-  focus
+
   it "prints all arguments provided" do
     header = Google::Gax::Headers.x_goog_api_client ruby_version: "1.2.3", lib_name: "foo", lib_version: "bar",
                                                     gapic_version: "4.5.6", gax_version: "7.8.9", grpc_version: "24601"

--- a/test/google/gax/headers/x_goog_api_client_test.rb
+++ b/test/google/gax/headers/x_goog_api_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016, Google LLC
+# Copyright 2019, Google LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -16,7 +16,7 @@
 # this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 # OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -27,18 +27,29 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require "google/gax/api_call"
-require "google/gax/configuration"
-require "google/gax/errors"
-require "google/gax/headers"
-require "google/gax/operation"
-require "google/gax/paged_enumerable"
-require "google/gax/protobuf"
-require "google/gax/stream_input"
-require "google/gax/version"
+require "test_helper"
+require "grpc"
 
-module Google
-  # Gax defines Google API extensions
-  module Gax
+describe Google::Gax::Headers, :x_goog_api_client do
+  focus
+  it "with no arguments" do
+    header = Google::Gax::Headers.x_goog_api_client
+    _(header).must_equal "gl-ruby/#{RUBY_VERSION} gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
+  end
+  focus
+  it "prints lib when provided" do
+    header = Google::Gax::Headers.x_goog_api_client lib_name: "foo", lib_version: "bar"
+    _(header).must_equal "gl-ruby/#{RUBY_VERSION} foo/bar gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
+  end
+  focus
+  it "prints gapic version when provided" do
+    header = Google::Gax::Headers.x_goog_api_client gapic_version: "foobar"
+    _(header).must_equal "gl-ruby/#{RUBY_VERSION} gapic/foobar gax/#{Google::Gax::VERSION} grpc/#{GRPC::VERSION}"
+  end
+  focus
+  it "prints all arguments provided" do
+    header = Google::Gax::Headers.x_goog_api_client ruby_version: "1.2.3", lib_name: "foo", lib_version: "bar",
+                                                    gapic_version: "4.5.6", gax_version: "7.8.9", grpc_version: "24601"
+    _(header).must_equal "gl-ruby/1.2.3 foo/bar gapic/4.5.6 gax/7.8.9 grpc/24601"
   end
 end


### PR DESCRIPTION
Moving this common code to Gax so the GAPIC client can do less.

Generator uses this change in googleapis/gapic-generator-ruby#157.