### PR TITLE
Update version and changelog for 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.7.1 / 2019-08-29
+
+* Fixed: Per-call timeout overrides from client configs are now honored.
+
 ### 1.7.0 / 2019-06-27
 
 * Support overrides of the service address and port for long-running operations.

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '1.7.0'.freeze
+    VERSION = '1.7.1'.freeze
   end
 end


### PR DESCRIPTION
gax doesn't use the usual release tools and needs to be released manually.