### PR TITLE
Require Ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ provide a more convenient and idiomatic API surface to callers.
 Ruby Versions
 ---------------
 
-gax-ruby is currently tested with Ruby 2.2.4.
+This library requires Ruby 2.4 or later.
+
+In general, this library supports Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
 
 Contributing

--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.license = 'BSD-3-Clause'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency 'googleauth', '>= 0.6.2', '< 0.10.0'
-  s.add_dependency 'grpc', '>= 1.7.2', '< 2.0'
-  s.add_dependency 'googleapis-common-protos', '>= 1.3.5', '< 2.0'
-  s.add_dependency 'google-protobuf', '~> 3.2'
+  s.add_dependency 'googleauth', '~> 0.10.0'
+  s.add_dependency 'grpc', '~> 1.24'
+  s.add_dependency 'googleapis-common-protos', '>= 1.3.9', '< 2.0'
+  s.add_dependency 'google-protobuf', '~> 3.9'
   s.add_dependency 'rly', '~> 0.2.3'
 
   s.add_development_dependency 'codecov', '~> 0.1'


### PR DESCRIPTION
Update Ruby dependency to 2.4, and update documentation to match.

Also updates:
* googleauth dependency to `~> 0.10.0` which will be the googleauth with the same Ruby 2.4 requirement.
* grpc and protobuf dependencies to the latest.
* googleapis-common-protos dependency to the latest.

Note: Tests will fail until googleauth 0.10.0 is actually released.