### PR TITLE
Release google-gax v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.8.0 / 2019-10-09
+
+This release requires Ruby 2.4 or later.
+
+* Update dependencies on googleauth, grpc, google-protobuf, and googleapis-common-protos.
+
 ### 1.7.1 / 2019-08-29
 
 * Fixed: Per-call timeout overrides from client configs are now honored.

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '1.7.1'.freeze
+    VERSION = '1.8.0'.freeze
   end
 end


### PR DESCRIPTION
This release requires Ruby 2.4 or later.

* Update dependencies on googleauth, grpc, google-protobuf, and googleapis-common-protos.
