### PR TITLE
Loosen dependency on googleauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.8.1 / 2019-10-10
+
+* Loosen dependency on googleauth to retain compatibility with googleauth 0.9 and older libraries that depend on it.
+
 ### 1.8.0 / 2019-10-09
 
 This release requires Ruby 2.4 or later.

--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency 'googleauth', '~> 0.10.0'
+  s.add_dependency 'googleauth', '~> 0.9'
   s.add_dependency 'grpc', '~> 1.24'
   s.add_dependency 'googleapis-common-protos', '>= 1.3.9', '< 2.0'
   s.add_dependency 'google-protobuf', '~> 3.9'

--- a/lib/google/gax/version.rb
+++ b/lib/google/gax/version.rb
@@ -29,6 +29,6 @@
 
 module Google
   module Gax
-    VERSION = '1.8.0'.freeze
+    VERSION = '1.8.1'.freeze
   end
 end


### PR DESCRIPTION
Allow googleauth 0.9.x. This should allow older libraries that depend on googleauth < 0.10 to coexist with newer libraries that depend on this version of gax.