### PR TITLE
Allow spaces in path template render bindings

### DIFF
--- a/lib/google/gax/path_template.rb
+++ b/lib/google/gax/path_template.rb
@@ -177,18 +177,16 @@ module Google
               msg = "Value for key #{segment.literal} is not provided"
               raise ArgumentError.new(msg)
             end
-            out.concat(PathTemplate.new(bindings[literal_sym]).segments)
+            out << bindings[literal_sym]
             binding = true
           elsif segment.kind == END_BINDING
             binding = false
           else
             next if binding
-            out << segment
+            out << segment.literal.to_s
           end
         end
-        path = self.class.format_segments(*out)
-        match(path)
-        path
+        out.join('/')
       end
 
       # Matches a fully qualified path template string.

--- a/spec/google/gax/path_template_spec.rb
+++ b/spec/google/gax/path_template_spec.rb
@@ -141,6 +141,20 @@ describe Google::Gax::PathTemplate do
       want = 'bar/1/2/foo/3'
       expect(template.render(**params)).to eq(want)
     end
+
+    it 'handles path values with spaces' do
+      template = PathTemplate.new('bar/**/foo/*')
+      params = symbolize_keys('$0' => '1 - 2', '$1' => '3')
+      want = 'bar/1 - 2/foo/3'
+      expect(template.render(**params)).to eq(want)
+    end
+
+    it 'handles named path values with spaces' do
+      template = PathTemplate.new('bar/{bif}/foo/{baz}')
+      params = symbolize_keys(bif: '1 - 2', baz: '3/4')
+      want = 'bar/1 - 2/foo/3/4'
+      expect(template.render(**params)).to eq(want)
+    end
   end
 
   describe 'method `to_s`' do


### PR DESCRIPTION
This change allows spaces to be present in the bindings passed to `PathTemplate#render`.