### PR TITLE
Specify minimum googleapis-common-protos-types dependency

### DIFF
--- a/google-gax.gemspec
+++ b/google-gax.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'googleauth', '~> 0.9'
   s.add_dependency 'grpc', '~> 1.24'
   s.add_dependency 'googleapis-common-protos', '>= 1.3.9', '< 2.0'
+  s.add_dependency 'googleapis-common-protos-types', '>= 1.0.4', '< 2.0'
   s.add_dependency 'google-protobuf', '~> 3.9'
   s.add_dependency 'rly', '~> 0.2.3'
 


### PR DESCRIPTION
The inherited common protos types dependency from google-protobuf `is ~> 1.0`, but libraries using newer annotations need at least version 1.0.4. Since Gax specifying an updated common protos dependency, it should specify an updated common protos types dependency as well.

[refs googleapis/google-cloud-ruby#4289]